### PR TITLE
Add organization KB mode test workflow

### DIFF
--- a/.agents/skills/kb-architect-pass/SKILL.md
+++ b/.agents/skills/kb-architect-pass/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: kb-architect-pass
+description: Run one repository-managed KB Architect mechanism-maintenance pass. Use only when a user or automation explicitly asks for KB Architect, architecture maintenance, automation/runbook/installer/proposal-queue maintenance, or the scheduled KB Architect automation; do not use for ordinary card content maintenance, Sleep consolidation, or Dream exploration.
+---
+
+# KB Architect Pass
+
+Run one Architect pass for the KB system's operating mechanisms.
+
+## Authority
+
+Work from the repository root. Treat these files as authoritative and read them before stateful mechanism work:
+
+- `PROJECT_SPEC.md`
+- `docs/architecture_runbook.md`
+- `.agents/skills/local-kb-retrieve/ARCHITECT_PROMPT.md`
+
+Current user instructions still override repository files.
+
+## Scope
+
+In scope: Sleep/Dream/Architect prompts, runbooks, automation specs, installer checks, rollback/snapshot/validation workflow, proposal queue governance, and narrow tests for those mechanisms.
+
+Out of scope: trusted-card rewrites, candidate promotion, card content merge/split/deprecation, taxonomy route rewrites, user preference cards, ordinary knowledge-card maintenance, dependency installs, broad refactors, and repo-wide formatting.
+
+## Execution Contract
+
+1. Write a visible Architect execution plan before the first stateful command, with every checkpoint present and status-tracked.
+2. Run Architect self-preflight against `system/knowledge-library/maintenance`.
+3. Run:
+   `python .agents/skills/local-kb-retrieve/scripts/kb_architect.py --json --sleep-cooldown-minutes 60 --dream-cooldown-minutes 20`
+4. Inspect generated artifacts under `kb/history/architecture/runs/<run-id>/`.
+5. Inspect `kb/history/architecture/proposal_queue.json`.
+6. Use only Evidence, Impact, and Safety for mechanism proposal review.
+7. Keep proposal statuses limited to `new`, `watching`, `ready-for-patch`, `ready-for-apply`, `applied`, `rejected`, and `superseded`.
+8. Do not use a human-review status; long-observation items remain `watching`.
+9. Apply only high-evidence high-safety mechanism changes inside prompt, runbook, validation, or proposal-queue maintenance with an immediate validation bundle.
+10. Generate patch plans for medium-safety mechanism changes instead of applying them directly.
+11. Confirm the runner's KB postflight observation or append one structured Architect observation if a new mechanism lesson was exposed.
+
+## Report
+
+Report the run id, checkpoint status for every plan item, preflight entries retrieved, proposal counts by status, ready-for-apply and ready-for-patch items, changes applied, validation bundle run, postflight observation status, and watching items left for long observation.

--- a/.agents/skills/kb-architect-pass/agents/openai.yaml
+++ b/.agents/skills/kb-architect-pass/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "KB Architect Pass"
+  short_description: "Run one KB Architect mechanism maintenance pass"
+  default_prompt: "Use $kb-architect-pass to run one KB Architect mechanism maintenance pass for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/kb-dream-pass/SKILL.md
+++ b/.agents/skills/kb-dream-pass/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: kb-dream-pass
+description: Run one bounded repository-managed local KB Dream exploration pass. Use only when a user or automation explicitly asks for KB Dream, dream mode, bounded KB exploration, or the scheduled KB Dream automation; do not use for Sleep consolidation, Architect mechanism work, ordinary preflight, or trusted-card maintenance.
+---
+
+# KB Dream Pass
+
+Run one bounded Dream pass for this predictive KB repository.
+
+## Authority
+
+Work from the repository root. Treat these files as authoritative and read them before stateful dream work:
+
+- `PROJECT_SPEC.md`
+- `docs/dream_runbook.md`
+- `.agents/skills/local-kb-retrieve/DREAM_PROMPT.md`
+
+Current user instructions still override repository files.
+
+## Execution Contract
+
+1. Keep Dream separate from Sleep and Architect.
+2. Run the dedicated dream runner:
+   `python .agents/skills/local-kb-retrieve/scripts/kb_dream.py --json --sleep-cooldown-minutes 45`
+3. Inspect generated artifacts under `kb/history/dream/<run-id>/`, including preflight, plan, opportunity, experiment, execution-plan, and report files.
+4. Require exactly one executable experiment before execution.
+5. Require experiment design, validation plan, safety tier, rollback plan, and explicit success/failure criteria.
+6. Keep write-back history-only or candidate-only.
+7. Keep external-system experiments proposal-only unless a human explicitly approves them in an active task.
+8. Do not rewrite trusted cards or taxonomy.
+9. Treat dream-created candidates as provisional until later live-task evidence confirms them.
+
+## Report
+
+Report the run id, retrieved preflight entries, selected experiment, execution-plan checkpoint status, safety tier and rollback plan, created candidates if any, history events written, run-level Dream-process observation, and anything still needing live-task confirmation.

--- a/.agents/skills/kb-dream-pass/agents/openai.yaml
+++ b/.agents/skills/kb-dream-pass/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "KB Dream Pass"
+  short_description: "Run one bounded local KB dream pass"
+  default_prompt: "Use $kb-dream-pass to run one bounded KB Dream pass for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/kb-organization-contribute/SKILL.md
+++ b/.agents/skills/kb-organization-contribute/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: kb-organization-contribute
+description: Run the repository-managed Khaos Brain organization contribution pass. Use only when a user or automation explicitly asks to export local shareable KB cards into a validated organization repository; no-op in personal mode or unvalidated organization settings.
+---
+
+# KB Organization Contribute
+
+Run one organization contribution pass for this predictive KB repository.
+
+## Authority
+
+Work from the repository root. Treat these files as authoritative before stateful contribution work:
+
+- `PROJECT_SPEC.md`
+- `docs/organization_mode_plan.md`
+- `.agents/skills/local-kb-retrieve/SKILL.md`
+
+Current user instructions still override repository files.
+
+## Execution Contract
+
+1. Use `scripts/kb_org_outbox.py --automation` as the entry point.
+2. The entry point must first read `.local/khaos_brain_desktop_settings.json`.
+3. If organization mode is not connected to a validated organization repository, exit successfully with a no-op result.
+4. Run KB preflight against `system/knowledge-library/organization` before exporting any proposals.
+5. Export only shareable model or heuristic cards with public scope and useful organization-level guidance.
+6. Do not export private cards, personal preferences, credentials, raw local paths, or raw machine identifiers.
+7. Use content hashes for duplicate prevention across current local cards, prior downloads, prior uploads, current organization cards, and current organization imports.
+8. Put eligible local cards into the organization outbox or import proposal path; leave merge approval to the organization repository and GitHub checks.
+9. When a card depends on a local Skill, upload it as a card-bound Skill bundle with `bundle_id`, `content_hash`, `version_time`, `original_author`, `readonly_when_imported: true`, and `update_policy: original_author_only`.
+10. If several local cards point at the same `bundle_id`, upload the local latest version for that bundle, not an older card-carried copy.
+11. Include Skill dependencies only when card evidence explains when the Skill is useful, what outcome it predicts, and what fallback exists.
+12. Run KB postflight after a non-skipped contribution pass and record the result as structured history.
+
+## Report
+
+Report the settings gate result, preflight entry ids, created/skipped proposal counts, content-hash duplicate decisions, card-bound Skill bundle ids and version hashes, branch or import proposal status, push or PR URL if attempted, postflight record path, and any errors.

--- a/.agents/skills/kb-organization-contribute/agents/openai.yaml
+++ b/.agents/skills/kb-organization-contribute/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "KB Organization Contribute"
+  short_description: "Export shareable local KB cards into the organization proposal lane"
+  default_prompt: "Use $kb-organization-contribute to run one settings-gated organization KB contribution pass for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/kb-organization-maintenance/SKILL.md
+++ b/.agents/skills/kb-organization-maintenance/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: kb-organization-maintenance
+description: Run the repository-managed Khaos Brain organization maintenance pass. Use only when a user or automation explicitly asks to inspect, review, or maintain a validated organization KB repository and this machine has opted into organization maintenance; this is the organization-level Sleep-like maintenance flow, not ordinary local KB Sleep.
+---
+
+# KB Organization Maintenance
+
+Run one organization-level Sleep-like maintenance pass for this predictive KB repository.
+
+## Authority
+
+Work from the repository root. Treat these files and Skills as authoritative before stateful organization maintenance:
+
+- `PROJECT_SPEC.md`
+- `docs/organization_mode_plan.md`
+- `.agents/skills/local-kb-retrieve/SKILL.md`
+- `$organization-review`
+
+Current user instructions still override repository files.
+
+## Execution Contract
+
+1. Use `scripts/kb_org_maintainer.py --automation` as the entry point.
+2. The entry point must first read `.local/khaos_brain_desktop_settings.json`.
+3. If organization mode is not validated or this machine has not opted into organization maintenance, exit successfully with a no-op result.
+4. Run KB preflight against `system/knowledge-library/organization` before inspecting organization candidates.
+5. Validate the organization manifest, expected paths, imports lane, candidates lane, trusted lane, Skill registry, and current Git state before proposing changes.
+6. Run the organization candidate intake checkpoint. Review new imports and candidates for reusable scenario, action, prediction, confidence, route, provenance, and public sharing value.
+7. Run the organization content-hash checkpoint. Use content hashes for duplicate analysis across trusted cards, candidates, imports, prior accepted uploads, and current proposals. Duplicate entry ids alone are not a maintenance blocker.
+8. Run the mandatory organization similar-card merge checkpoint. Inspect overlapping organization cards by scenario, action, prediction, route, evidence, and content hash. Decide whether to merge, propose a merge, supersede, or skip application with a concrete reason.
+9. Run the mandatory organization overloaded-card split checkpoint. Inspect broad, recurrent, or multi-branch organization cards and decide whether each is still a useful hub, should move toward a split proposal, or should skip application with a concrete reason.
+10. Run the organization candidate decision checkpoint. For each reviewed card bundle, decide whether to approve/promote, reject with reason, keep as candidate, supersede, deprecate, merge, or split. Do not skip the decision checkpoint itself.
+11. Apply the `$organization-review` contract to card candidates, card-and-Skill bundles, Skill registry changes, privacy boundaries, and GitHub auto-merge readiness.
+12. Run the organization Skill safety checkpoint. For every declared Skill dependency or Skill candidate, check card evidence, public usefulness, privacy boundaries, install risk, `bundle_id`, `sha256:` content hash, fallback behavior, read-only import behavior, and status.
+13. Run the organization Skill bundle version checkpoint. Group Skill bundles by `bundle_id`; approve only original-author updates on the same bundle, treat non-author changes as forks with new `bundle_id`, and select the latest approved version by `version_time` for organization distribution.
+14. Treat `candidate`, `approved`, and `rejected` as the first-pass Skill review states. Do not auto-install or recommend auto-install for candidate, rejected, unknown, unpinned, or non-hash-verified Skills.
+15. Prefer candidate/import paths for automatic maintenance. Treat trusted cards, registry changes, policy changes, organization-review changes, and approved-Skill registry changes as higher risk.
+16. Run the GitHub merge-readiness checkpoint. Confirm changed paths, low-risk lane eligibility, required checks, rollback story, and whether the PR should be auto-merge eligible or remain review-only.
+17. Do not skip the merge, split, candidate-decision, Skill-safety, Skill-bundle-version, or GitHub-readiness checkpoints. It is acceptable to skip applying a change when evidence, safety, tooling, permissions, or scope is insufficient, but the inspection and recorded decision must still happen.
+18. Run KB postflight after a non-skipped maintenance pass and record the result as structured history.
+
+## Report
+
+Report the settings gate result, participation status, preflight entry ids, organization manifest status, candidate/import counts, content-hash duplicate decisions, organization merge checkpoint decisions, organization split checkpoint decisions, candidate approval/rejection decisions, Skill dependency decisions, Skill bundle version decisions, GitHub merge-readiness result, organization-review availability, recommendations, postflight record path, and any errors.

--- a/.agents/skills/kb-organization-maintenance/agents/openai.yaml
+++ b/.agents/skills/kb-organization-maintenance/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "KB Organization Maintenance"
+  short_description: "Inspect and review a validated organization KB repository"
+  default_prompt: "Use $kb-organization-maintenance to run one settings-gated organization KB maintenance pass for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/kb-sleep-maintenance/SKILL.md
+++ b/.agents/skills/kb-sleep-maintenance/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: kb-sleep-maintenance
+description: Run the repository-managed local KB Sleep maintenance pass. Use only when a user or automation explicitly asks for KB Sleep, sleep maintenance, local KB consolidation, or the scheduled KB Sleep automation; do not use for ordinary task preflight or active-task KB writes.
+---
+
+# KB Sleep Maintenance
+
+Run one dedicated Sleep maintenance pass for this predictive KB repository.
+
+## Authority
+
+Work from the repository root. Treat these files as authoritative and read them before stateful maintenance:
+
+- `PROJECT_SPEC.md`
+- `docs/maintenance_runbook.md`
+- `.agents/skills/local-kb-retrieve/MAINTENANCE_PROMPT.md`
+
+Current user instructions still override repository files.
+
+## Execution Contract
+
+1. Write a visible execution plan before the first stateful command, with checkpoint statuses.
+2. Run the sleep self-preflight search against `system/knowledge-library/maintenance`.
+3. Inspect taxonomy, route gaps, route navigation when needed, and proposal-mode consolidation output.
+4. Run the mandatory similar-card merge checkpoint. Inspect cards surfaced by maintenance output for overlapping scenario, action, prediction, route, or evidence. Decide whether to merge, propose a merge, or skip application with a concrete reason.
+5. Run the mandatory overloaded-card split checkpoint. Inspect recurrent, broad, or `split_review_suggestion` cards and decide whether each one is still a hub card, should move toward a split proposal, or should skip application with a concrete reason.
+6. Run the organization Skill bundle consolidation checkpoint. For imported read-only organization Skills, group by `bundle_id`, keep only the latest approved version by `version_time`, preserve source-card references, and keep all local cards pointing at the same `bundle_id`.
+7. Do not skip the merge, split, or Skill bundle consolidation checkpoint itself. It is acceptable to skip applying a merge, split, or Skill replacement when evidence, safety, tooling, or scope is insufficient, but the inspection and recorded decision must still happen.
+8. Prefer functional, reusable domain paths over project-name route roots when reviewing candidates.
+9. Continue through every safe checkpoint instead of stopping after a short proposal.
+10. Apply only clearly eligible low-risk lanes supported by current tooling: new-candidates, related-cards, cross-index, AI-authored semantic-review, and AI-authored zh-CN i18n.
+11. Limit semantic-review to at most 3 trusted-card modifications per run.
+12. Run zh-CN display translation cleanup after candidate/card creation or semantic text changes.
+13. Keep taxonomy rewrites proposal-only unless current tooling cleanly supports the exact change.
+14. Inspect rollback artifacts when needed.
+15. Attempt supported low-risk repairs and rerun the relevant validation when a command exposes a fixable issue.
+16. Run a final sleep postflight check.
+17. Append one structured maintenance observation when the pass exposed a reusable lesson, route gap, card weakness, merge signal, split signal, Skill bundle update, or process hazard.
+18. Stop after that final observation. Do not immediately consolidate the observation just written.
+
+## Report
+
+Report the run id, checkpoint status, self-preflight entries, observation counts reviewed, candidates created, route adjustments or concerns, similar-card merge checkpoint decisions, overloaded-card split checkpoint decisions, organization Skill bundle consolidation decisions, semantic-review decisions applied or skipped, translations updated or still missing, validations run, repaired or proposal-only issues, maintenance decisions, postflight observation status, undeclared taxonomy gaps, hub-vs-overloaded card reviews, and next proposal-only targets.

--- a/.agents/skills/kb-sleep-maintenance/agents/openai.yaml
+++ b/.agents/skills/kb-sleep-maintenance/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "KB Sleep Maintenance"
+  short_description: "Run the local KB sleep maintenance pass"
+  default_prompt: "Use $kb-sleep-maintenance to run one local KB Sleep maintenance pass for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/local-kb-retrieve/SKILL.md
+++ b/.agents/skills/local-kb-retrieve/SKILL.md
@@ -52,7 +52,7 @@ Independent maintenance thread:
 6. Prefer entries with stronger route alignment, `status: trusted`, and higher `confidence`.
 7. Use retrieved entries as bounded context. Do not overgeneralize beyond the entry scope.
 8. If no relevant entries are found, continue without forcing the library into the answer; the absence of hits is still a useful signal.
-9. Before finalizing any non-trivial task, run one explicit KB postflight check: did this task expose a reusable lesson, a miss, a route gap, a card weakness, or a KB-process failure?
+9. Before finalizing any non-trivial task, run one explicit KB postflight check: did this task expose a reusable lesson, a skill/plugin or subagent/delegation usage lesson, a miss, a route gap, a card weakness, or a KB-process failure?
 10. If the answer is yes, let `kb-recorder` append structured feedback so the scheduled AI consolidation flow can process it later. When more than one card materially influenced the task, record all of those entry ids rather than only the top hit.
 11. If the answer is no, make that an explicit conclusion rather than silently forgetting to check.
 12. If a reusable new lesson emerges during the task, record it into candidates or structured history rather than trying to fully consolidate it inside the active task thread.
@@ -63,6 +63,7 @@ Independent maintenance thread:
 17. When such a lesson is likely to become a card later, keep more than one retrieval path in view: a runtime-facing route such as `codex/runtime-behavior/...` plus any prompting, tool-use, workflow, or planning routes that materially shaped the behavior.
 18. Lessons about a specific user are also valid when they stay bounded, evidence-based, and behaviorally framed. Record them as task-conditioned private predictions about likely preference, correction, or judgment rather than as personality labels or broad character impressions.
 19. Lessons about Codex Skill or plugin use are valid personal-KB evidence when the Skill is new, repeatedly useful, task-critical, missing, misleading, used as fallback, combined with another Skill, or when the task shows that a Skill should be invoked earlier or avoided under known conditions. Do not record generic praise or every routine invocation; record scenario, Skill action/choice, observed result, and future operational use. Preserve a skill-facing route such as `codex/workflow/skills` or `codex/skill-use/<skill-name>` plus the task-facing route that made the Skill relevant.
+20. Lessons about Codex subagent/delegation use are valid personal-KB evidence when spawning, avoiding, sequencing, waiting for, or parallelizing subagents materially changes speed, coordination overhead, context isolation, main-thread clarity, verification quality, or task outcome. Do not record generic praise for parallelism or every routine sidecar; record scenario, delegation action/choice, observed result, and future operational use. Preserve a workflow-facing route such as `codex/workflow/subagents` plus the task-facing route that made delegation relevant.
 
 Sleep maintenance checklist:
 
@@ -104,6 +105,7 @@ Output discipline:
 - Do not expose private entry content unless the user is authorized to see it.
 - User-specific lessons should default to private handling and should describe what this user is likely to prefer or reject in a concrete task context, not who the user “is” in general.
 - Keep sidecar agents scoped: `kb-scout` should be read-mostly and `kb-recorder` should default to history, comments, and candidate writes rather than broad structural edits.
+- Record subagent/delegation usage lessons when sidecars materially helped or hurt speed, main-thread focus, context isolation, verification, or integration.
 - In a maintenance thread, be explicit about what the tooling actually changed versus what still remains a proposal.
 - For non-trivial work, treat the explicit postflight observation check as part of done rather than optional housekeeping.
 - After meaningful tasks, prefer recording one structured observation even when the outcome was a workflow or rule clarification. Sleep maintenance depends on accumulated evidence, not only on bug-fix episodes.

--- a/.agents/skills/organization-review/SKILL.md
+++ b/.agents/skills/organization-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: organization-review
+description: Review Khaos Brain organization KB maintenance proposals, including card-and-Skill bundles, shared Skill safety, evidence quality, privacy boundaries, and GitHub auto-merge readiness. Use before approving, rejecting, merging, splitting, or promoting organization KB candidates or organization Skill registry changes.
+---
+
+# Organization Review
+
+Use this Skill when reviewing organization KB changes or running full
+organization maintenance automation.
+
+## Review Contract
+
+Treat the review unit as a bundle, not a standalone file:
+
+- candidate card or trusted-card change;
+- declared Skill dependency or Skill registry change;
+- task evidence and provenance;
+- privacy and sharing policy impact;
+- GitHub merge path and rollback story.
+
+Do not approve a Skill only because it exists. A Skill becomes organization
+knowledge only when cards explain when it is useful, what outcome it predicts,
+what fallback exists, and what evidence supports it.
+
+## Required Checks
+
+1. Validate the organization repository manifest and expected paths.
+2. Confirm changed paths match the intended merge lane.
+3. Reject raw private preferences, credentials, tokens, local absolute paths,
+   hardware identifiers, or user-specific interaction memories.
+4. For cards, check that scenario, action, prediction, confidence, route, and
+   operational use are organization-reusable.
+5. For Skill dependencies, check that each dependency is required, recommended,
+   or optional and has evidence from one or more cards.
+6. For card-bound Skill bundles, require `bundle_id`, `content_hash`,
+   `version_time`, `original_author`, read-only import behavior, and
+   `update_policy: original_author_only`.
+7. For same-`bundle_id` updates, approve only original-author updates and use
+   `version_time` to select the latest approved version; non-author changes
+   must fork to a new `bundle_id`.
+8. For approved Skills, require a pinned version or version time and `sha256:`
+   content hash.
+9. Do not auto-install or recommend auto-install for `candidate`, `rejected`,
+   unknown, or unpinned Skills.
+10. Prefer import/candidate paths for automatic merge. Treat trusted-card,
+   registry, policy, and organization-review Skill changes as higher risk.
+11. Record rejection reasons when a bundle is weak, unsafe, private, too local,
+   duplicated, or missing evidence.
+12. Keep the output reviewable: summarize accepted changes, rejected changes,
+    unresolved risks, checks run, and the exact GitHub branch or PR path.
+
+## Decision Labels
+
+- `candidate`: unreviewed or still gathering evidence.
+- `approved`: reviewed with sufficient card evidence and safe install metadata.
+- `rejected`: reviewed and not recommended; keep the reason as an audit signal.
+
+Avoid inventing additional first-pass states unless repository policy has been
+updated to support them.

--- a/.agents/skills/organization-review/agents/openai.yaml
+++ b/.agents/skills/organization-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Organization Review"
+  short_description: "Review organization KB card-and-Skill bundles safely."
+  default_prompt: "Review this organization KB maintenance proposal for evidence quality, privacy, Skill safety, and merge readiness."

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - https://paypal.me/Yingxuliu

--- a/.github/actions/org-kb-check/action.yml
+++ b/.github/actions/org-kb-check/action.yml
@@ -1,0 +1,32 @@
+name: Organization KB Check
+description: Validate a Khaos Brain organization KB repository for maintenance pull requests.
+inputs:
+  org-root:
+    description: Organization KB repository root.
+    required: false
+    default: "."
+  changed-files-file:
+    description: Text file containing changed files, one per line.
+    required: false
+    default: ""
+  enforce-low-risk:
+    description: Fail when changed files are not eligible for low-risk auto-merge.
+    required: false
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - name: Install Python dependencies
+      shell: bash
+      run: python -m pip install pyyaml
+    - name: Run organization KB checks
+      shell: bash
+      run: |
+        args=(--org-root "${{ inputs.org-root }}")
+        if [ -n "${{ inputs.changed-files-file }}" ]; then
+          args+=(--changed-files-file "${{ inputs.changed-files-file }}")
+        fi
+        if [ "${{ inputs.enforce-low-risk }}" = "true" ]; then
+          args+=(--enforce-low-risk)
+        fi
+        python "$GITHUB_ACTION_PATH/../../../scripts/kb_org_check.py" "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ kb/history/*
 !kb/history/.gitkeep
 
 kb/candidates/*.yaml
+kb/outbox/
 kb/history/consolidation/
 .local/
 tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,11 @@
 - Immediately after installation, run `python scripts/install_codex_kb.py --check --json` and confirm the install is healthy before doing anything else.
 - Treat the installer as idempotent. If the system may already be installed, rerun the installer anyway rather than asking the user to verify it manually.
 - If this repository was moved to a new path or re-cloned, rerun the installer from the new clone so the Codex-side manifest points at the current KB root.
-- The installed global preflight skill must enable implicit invocation and must remind Codex to record KB postflight observations after meaningful work. Treat either missing behavior as an installation defect and fix it.
+- The installed global preflight skill must enable implicit invocation and must remind Codex to record KB postflight observations after meaningful work, including skill/plugin and subagent/delegation usage lessons when they materially affect task outcomes. Treat missing behavior as an installation defect and fix it.
+- The installer must also refresh the repository-managed `kb-sleep-maintenance`, `kb-dream-pass`, and `kb-architect-pass` skills under `$CODEX_HOME/skills`; these skills are explicit maintenance entry points and should not enable broad implicit invocation.
 - The installer must also refresh the repository-managed `KB Sleep`, `KB Dream`, and `KB Architect` cron automations under `$CODEX_HOME/automations` so another machine inherits the same maintenance cadence after bootstrap; these automations should use the strongest available model and deepest reasoning policy instead of pinning a fixed model slug.
 - The installer must also write or refresh a repository-managed global defaults block under `$CODEX_HOME/AGENTS.md` so other machines inherit the strongest available session-wide KB preflight and postflight rules, not only the implicit skill layer.
-- The install check must expose a structured machine-install checklist that explicitly verifies the global skill files, implicit invocation, postflight reminder wording, managed global AGENTS block, all repo-managed automations, and the final `strong_session_defaults` readiness signal.
+- The install check must expose a structured machine-install checklist that explicitly verifies the global skill files, implicit invocation, postflight reminder wording, skill/plugin and subagent/delegation signal wording, managed global AGENTS block, repo-managed maintenance skills, all repo-managed automations, and the final `strong_session_defaults` readiness signal.
 
 ## Start here
 

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -235,6 +235,15 @@ The repository should be organized so the file system itself supports the concep
 │  └─ maintenance_runbook.md
 ├─ .agents/
 │  └─ skills/
+│     ├─ kb-sleep-maintenance/
+│     │  ├─ SKILL.md
+│     │  └─ agents/openai.yaml
+│     ├─ kb-dream-pass/
+│     │  ├─ SKILL.md
+│     │  └─ agents/openai.yaml
+│     ├─ kb-architect-pass/
+│     │  ├─ SKILL.md
+│     │  └─ agents/openai.yaml
 │     └─ local-kb-retrieve/
 │        ├─ ARCHITECT_PROMPT.md
 │        ├─ SKILL.md
@@ -285,7 +294,7 @@ Codex currently discovers repository skills from `.agents/skills/...`, and a ski
 
 Each entry should support the following structure:
 
-- `id`: stable identifier
+- `id`: stable system reference handle, not the content identity
 - `title`: short readable title
 - `type`: `model`, `preference`, `heuristic`, or `fact`
 - `scope`: `public` or `private`
@@ -312,6 +321,7 @@ A card is operational, not merely descriptive.
 - `predict` defines the expected result
 - `use` defines what Codex should do because of that prediction
 - `related_cards` defines a small direct-navigation surface between cards that are repeatedly used together; it is not a concept graph and should stay short
+- `id` is used for references, UI handles, history targets, and filenames. New card ids should be generated from a timestamp, a sanitized author or local-installation short label, and random code. They must not embed raw machine identifiers. Exact duplicate detection should use normalized `content_hash`, not `id`.
 
 This keeps the knowledge unit useful for action selection.
 
@@ -404,6 +414,7 @@ The skill should do the following:
 11. When recording such a lesson, preserve both the runtime-facing route and any workflow or prompting routes that materially shaped the behavior, so later retrieval can find the card from more than one valid direction.
 12. When a reusable lesson is specifically about how a user tends to respond, prefer a private predictive card that captures the task condition and likely user preference or reaction, rather than a vague impression about the user's personality.
 13. When a reusable lesson is specifically about using another Codex skill or plugin, capture it as valid KB evidence when the skill choice, ordering, combination, fallback, or failure mode materially changes the result. Preserve both a skill-facing route such as `codex/workflow/skills` or `codex/skill-use/<skill-name>` and the task-facing route that made the skill relevant.
+14. When a reusable lesson is specifically about Codex subagent or delegation use, capture it as valid KB evidence when the decision to spawn, avoid, sequence, wait for, or parallelize subagents materially changes speed, coordination overhead, context isolation, main-thread clarity, verification quality, or task outcome. Preserve both a workflow-facing route such as `codex/workflow/subagents` and the task-facing route that made delegation relevant.
 
 Skill-use evidence should be captured as part of the personal KB, not only as a
 future organization-sharing concern. This should not mean writing an observation
@@ -412,9 +423,18 @@ observation when a Skill is new, repeatedly useful, task-critical, missing,
 misleading, used as a fallback, combined with another Skill, or when the task
 reveals that a Skill should be invoked earlier or avoided in a known scenario.
 
+Subagent/delegation evidence should be captured at the same level as Skill-use
+evidence. This should not mean writing an observation for every sidecar agent.
+It does mean Codex should record a structured observation when delegation was
+new, repeatedly useful, task-critical, slower than expected, avoided for good
+reason, caused coordination overhead, protected the main thread from distraction,
+or made retrieval, implementation, verification, or integration materially
+clearer.
+
 For non-trivial work, KB postflight should be treated as part of done rather than optional housekeeping. Before a task is considered complete, Codex should explicitly check whether the task exposed:
 
 - a reusable lesson
+- a skill/plugin or subagent/delegation usage lesson
 - a retrieval miss
 - a route gap
 - a card weakness
@@ -812,6 +832,23 @@ Skill-use observation before proposing that Skill as reusable organization
 capability. The observation should explain the card-facing evidence for the
 Skill, not merely state that the Skill exists.
 
+Observations about **subagent or delegation use** should follow the same
+predictive rule. They are valid when they answer:
+
+- which subagent, sidecar role, or delegation pattern was selected, skipped,
+  sequenced, waited on, or used as a fallback
+- under what task conditions that delegation choice mattered
+- what outcome changed because of the delegation choice, coordination cost, or
+  isolation benefit
+- how future Codex work should adapt its subagent spawning, waiting,
+  integration, or fallback behavior
+
+These observations should avoid generic praise for parallelism. The useful
+evidence is the trigger condition, delegation action, observed result, and
+future operational rule, especially when subagents made the task faster or
+slower, kept the main thread clearer, prevented context pollution, improved
+verification coverage, or added unnecessary coordination overhead.
+
 Observations about a **specific user** should also stay predictive and bounded. They are strongest when they answer:
 
 - in what task or interaction context the behavior appeared
@@ -827,6 +864,10 @@ When later card creation is likely, Codex should preserve enough route context t
 - a task-facing route such as `prompting/...`, `codex/workflow/...`, or another route that captures the condition that exposed the behavior
 
 Skill-use observations should be similarly reachable from both a skill-facing route, such as `codex/workflow/skills` or `codex/skill-use/<skill-name>`, and the task-facing route that made the skill relevant.
+
+Subagent-use observations should likewise be reachable from both a workflow
+route such as `codex/workflow/subagents` or `codex/delegation/<pattern>` and
+the task-facing route that made delegation relevant.
 
 Card creation should then happen mainly during scheduled AI consolidation:
 
@@ -978,7 +1019,14 @@ The default cadence is after Sleep and Dream, for example:
 - `KB Dream`: 13:00
 - `KB Architect`: 14:00
 
-The installer should provision all three repository-managed automations, and the install check should verify all three.
+The installer should provision all three repository-managed maintenance skills (`kb-sleep-maintenance`, `kb-dream-pass`, and `kb-architect-pass`) plus all three repository-managed automations, and the install check should verify all six. The maintenance skills are explicit entry points for scheduled or manual maintenance; they should remain narrow and should not enable broad implicit invocation.
+
+Each automation prompt should explicitly name its maintenance skill (`$kb-sleep-maintenance`, `$kb-dream-pass`, or `$kb-architect-pass`) while preserving enough fallback markers for install checks to detect prompt drift. Cron automation remains responsible for schedule, workspace, model policy, and reasoning policy; the skill owns the maintenance workflow contract.
+
+The install check should also verify that the global predictive KB defaults
+name both skill/plugin usage lessons and subagent/delegation usage lessons as
+recordable KB signals, so cross-machine installs inherit both workflow-learning
+paths.
 
 Automation specs must encode model intent as `model_policy = "strongest-available"` and `reasoning_effort_policy = "deepest"` rather than pinning a fixed model slug. During installation, the repo installer resolves that policy against the current machine's Codex model cache/config, writes the concrete runtime values into the automation files, and records the policy fields so future machines can pick newer models without changing the spec.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ The two screenshots below show the current desktop app in English UI, intended a
 - 它不会把 `kb/private/`、`kb/history/`、`kb/candidates/` 或真实经验卡片封进二进制
 - 源码入口仍然是 `python scripts/kb_desktop.py --repo-root . --language en`
 
+### 自愿支持项目维护
+
+如果这个项目对你有帮助，你可以通过下面的链接自愿支持项目维护：
+
+[通过 PayPal 请开发者喝杯咖啡](https://paypal.me/Yingxuliu)
+
+所有支持都是自愿的，不代表购买技术支持、质保、优先服务、商业授权或功能定制。
+
 ### 手动安装与检查（可选）
 
 如果你是协作者，或者你就是想手动跑一遍：
@@ -191,7 +199,7 @@ python scripts/kb_desktop.py --repo-root . --language en
 
 如果需要 Windows exe、桌面快捷方式或 Codex 打开 UI 的 skill，见 `docs/windows_desktop_app.md`。
 
-如果你在评估下一阶段的组织共享模式，见 `docs/organization_mode_plan.md`。它记录了 GitHub-backed organization KB、身份、权限、Skill registry、贡献管线和 UI 分层的计划，但还不是默认启用功能。
+如果你在评估可选的组织共享模式，见 `docs/organization_mode_plan.md`。个人模式仍是默认入口；只有在 Settings 里配置并验证一个 Khaos organization KB GitHub 仓库后，组织来源、组织卡片、Skill registry 和贡献管线才会启用。
 
 无界面检查可以运行：
 
@@ -368,6 +376,14 @@ The current GitHub Release includes the Windows preview entry `KhaosBrain.exe`:
 - it does not bundle `kb/private/`, `kb/history/`, `kb/candidates/`, or real memory cards into the binary
 - the source entry remains `python scripts/kb_desktop.py --repo-root . --language en`
 
+### Voluntary Support
+
+If this project is useful to you, you can support its development here:
+
+[Buy me a coffee via PayPal](https://paypal.me/Yingxuliu)
+
+Contributions are voluntary and do not purchase support, warranty, priority service, commercial rights, or feature requests.
+
 ### Manual Install And Check (Optional)
 
 If you are a collaborator, or you simply want to run it yourself:
@@ -412,7 +428,7 @@ The desktop viewer supports a local display-language setting. English card field
 
 For the Windows exe, desktop shortcut, or Codex UI-opening skill, see `docs/windows_desktop_app.md`.
 
-For the planned organization-sharing direction, see `docs/organization_mode_plan.md`. It records the proposed GitHub-backed organization KB, identity, permissions, Skill registry, contribution pipeline, and UI layering, but it is not enabled by default yet.
+For the optional organization-sharing mode, see `docs/organization_mode_plan.md`. Personal mode remains the default. Organization sources, organization cards, the Skill registry, and the contribution pipeline are enabled only after Settings validates a Khaos organization KB GitHub repository.
 
 For a headless check:
 

--- a/docs/organization_functional_acceptance.md
+++ b/docs/organization_functional_acceptance.md
@@ -1,0 +1,304 @@
+# Organization Functional Acceptance Plan
+
+This document defines the functional acceptance plan for Khaos Brain
+organization mode. It is intentionally test-first: before broad cleanup or
+module reshaping, each important behavior should have an executable test or an
+explicit manual verification checklist.
+
+## Acceptance Strategy
+
+Use three validation layers:
+
+1. Unit and module tests keep small rules stable.
+2. End-to-end tests simulate realistic user and repository flows with temporary
+   local directories.
+3. Manual UI checks confirm the desktop experience is understandable and does
+   not expose technical metadata in the wrong place.
+
+Do not start large structural cleanup until the end-to-end acceptance suite
+locks the intended behavior. Small local fixes are allowed while adding tests.
+Large design problems should be recorded in a validation report before
+architecture changes are made.
+
+## Core Functional Areas
+
+### 1. Personal Mode Baseline
+
+Purpose: organization mode must not damage the single-user local KB workflow.
+
+Acceptance checks:
+
+- A fresh or default settings file opens in personal mode.
+- Missing organization settings do not show organization sources or organization
+  navigation.
+- Local search returns local cards only.
+- Local route, status, type, and source filters still work.
+- Local card detail opens and shows if/action/predict/use sections.
+- Language switching does not change canonical card content or hide data.
+- Cards with Skill dependencies show a compact cover badge and detail still
+  shows the exact dependency list.
+
+Recommended tests:
+
+- `tests/test_e2e_personal_mode.py`
+- Existing supporting tests: `test_kb_desktop_ui.py`,
+  `test_desktop_settings.py`, `test_search_rejected_candidates.py`.
+
+### 2. Organization Source Connection
+
+Purpose: organization mode should activate only after a valid organization KB
+source is configured and mirrored.
+
+Acceptance checks:
+
+- A repository without `khaos_org_kb.yaml` is rejected.
+- A repository with invalid kind, schema, or missing required KB paths is
+  rejected.
+- A valid local or Git-backed organization repo is mirrored and validated.
+- Existing mirrors are synchronized into the local organization cache before
+  organization browsing uses them.
+- GitHub identity discovery and maintainer controls are gated behind validated
+  organization mode.
+- Switching back to personal mode removes organization search and browsing
+  sources without deleting local KB data.
+
+Recommended tests:
+
+- `tests/test_e2e_organization_connection.py`
+- Existing supporting tests: `test_org_sources.py`,
+  `test_desktop_settings.py`, `test_org_automation.py`.
+
+### 3. Multi-Source Search And Read-Only Browsing
+
+Purpose: local and organization cards should appear in one usable browsing
+surface with clear source labels.
+
+Organization browsing uses synchronized local mirrors as the organization
+cache pool. Runtime search should read that local cache, not reach out to the
+remote repository for every query.
+
+Acceptance checks:
+
+- Local results rank before organization results for equal relevance.
+- Organization cards are marked read-only.
+- Source labels distinguish local public/private/candidate from organization
+  trusted/candidate cards.
+- Author display falls back clearly when organization author metadata is absent.
+- Exact same-hash organization cards are hidden when the content already exists
+  locally.
+- Same card id with different content hash can surface as a new organization
+  version.
+
+Recommended tests:
+
+- `tests/test_e2e_multi_source_browsing.py`
+- Existing supporting tests: `test_multi_source_search.py`,
+  `test_organization_adoption.py`.
+
+### 4. Organization Card Adoption On Use
+
+Purpose: an organization card becomes local maintenance material only after it
+is actually used.
+
+Acceptance checks:
+
+- Merely viewing or searching an organization card does not create a local
+  adopted copy.
+- Using an organization card creates one adopted candidate if its exchange hash
+  is new locally.
+- If the same exchange hash already exists locally, no duplicate adopted file
+  is created.
+- Reusing the same organization card updates local usage metadata rather than
+  creating another copy.
+- Deleting a local adopted copy does not make the same downloaded hash reappear
+  as new organization content.
+- A later organization card with a different exchange hash can surface again.
+
+Recommended tests:
+
+- `tests/test_e2e_organization_adoption.py`
+- Existing supporting tests: `test_organization_adoption.py`.
+
+### 5. Card-Bound Skill Bundle Lifecycle
+
+Purpose: Skills should follow cards, but Skill identity and deduplication should
+remain stable across machines.
+
+Acceptance checks:
+
+- A local card that depends on a local Skill exports a card-bound Skill bundle
+  in the organization outbox.
+- The bundle records `bundle_id`, `content_hash`, `version_time`,
+  `original_author`, read-only import behavior, and update policy.
+- Multiple local cards pointing to the same `bundle_id` export the local latest
+  version, not an older card-carried copy.
+- An organization card with a card-bound Skill bundle installs that bundle into
+  local organization Skill storage when the card is adopted.
+- Local imported organization Skill storage keeps only the latest approved
+  version per `bundle_id`.
+- Duplicate Skill names or ids do not define identity.
+- Approved Skill auto-install requires an approved status, pinned version or
+  version time, pinned sha256 content hash, and local policy permission.
+- Candidate, rejected, unknown, or unpinned Skills are not silently installed.
+
+Recommended tests:
+
+- `tests/test_e2e_skill_bundle_lifecycle.py`
+- Existing supporting tests: `test_skill_sharing.py`,
+  `test_organization_adoption.py`, `test_org_checks.py`.
+
+### 6. Local-To-Organization Contribution Flow
+
+Purpose: local machines should contribute only reusable public knowledge and
+avoid duplicate exchange payloads.
+
+Acceptance checks:
+
+- Public model and heuristic cards can be exported as organization candidates.
+- Private cards, preference cards, user-specific cards, and clean adopted
+  organization cards are skipped.
+- The same exchange hash is exported at most once in one outbox.
+- Hashes already exported from this installation are skipped.
+- Hashes already present in the current organization repository are skipped.
+- Outbox files can be copied into an organization repo import branch with nested
+  Skill bundle files preserved.
+- Low-risk import paths can pass organization checks.
+- Protected trusted-card changes are blocked by low-risk checks.
+
+Recommended tests:
+
+- `tests/test_e2e_org_contribution_flow.py`
+- Existing supporting tests: `test_org_outbox.py`,
+  `test_org_contribution.py`, `test_org_checks.py`,
+  `test_org_multi_machine.py`.
+
+### 7. Organization Maintenance Cleanup
+
+Purpose: organization maintenance must make the shared library cleaner, not only
+validate file formats.
+
+Acceptance checks:
+
+- Exact duplicate card content hashes across trusted, candidate, and import
+  paths are detected.
+- A duplicate of local or organization trusted content is not promoted as a new
+  organization experience.
+- Weak or random candidate cards are marked as not recommended, rejected, or
+  kept out of the trusted path.
+- Similar candidate cards produce a merge proposal or a consolidated card
+  proposal.
+- Overloaded candidate cards produce a split proposal or an explicit
+  skip-with-reason decision.
+- Superseded cards are marked deprecated/superseded or folded into the stronger
+  replacement.
+- Trusted cards may receive confidence adjustments, status adjustments,
+  rewrites, merges, splits, or deletion proposals when evidence supports the
+  change.
+- Deletion is allowed in the long-term organization maintenance model, but it
+  must be proposal-driven, audited, and recoverable through Git history or a
+  tombstone/audit record.
+- Confidence adjustments are first-class maintenance actions. They should move
+  gradually unless the evidence is strong enough for a larger status change.
+- Merging cards preserves source evidence, authorship metadata, history, and
+  Skill dependencies.
+- If merged cards depend on the same Skill bundle, the merged result points at
+  one latest approved bundle version.
+- If a card is rejected, its unapproved card-bound Skill bundle is not promoted
+  to approved.
+
+Recommended tests:
+
+- `tests/test_e2e_organization_maintenance_cleanup.py`
+- Existing supporting tests: `test_org_checks.py`,
+  `test_org_maintenance.py`, `test_kb_consolidate_apply_worker1.py`,
+  `test_kb_semantic_review.py`.
+
+## Multi-Machine Scenario
+
+The main end-to-end scenario should simulate:
+
+```text
+tmp/
+  org_repo/
+  machine_a/
+  machine_b/
+```
+
+Flow:
+
+1. Create a valid organization KB repository.
+2. Create machine A with a public reusable card and a local Skill.
+3. Connect machine A and machine B to the organization repo.
+4. Machine A exports an organization outbox item with the card-bound Skill
+   bundle.
+5. Copy the outbox into the organization repo import path.
+6. Run organization checks.
+7. Machine B searches organization content.
+8. Machine B finds organization content from its synchronized local
+   organization cache pool.
+9. Machine B adopts one organization card only after use.
+10. Machine B receives the card-bound Skill bundle locally.
+11. Machine B modifies the adopted card into reusable feedback.
+12. Machine B exports feedback only if the new exchange hash is not already
+    known.
+13. Organization maintenance detects duplicates, weak candidates, and merge
+    opportunities before any promotion.
+
+This scenario should stay local and deterministic. A live private GitHub
+sandbox test can be run later as a manual or integration smoke test, but local
+temporary repos should be the default automated acceptance path.
+
+## Manual UI Acceptance
+
+Manual checks should be run after the e2e tests pass:
+
+- Settings dialog: personal/organization mode dropdowns are readable.
+- Organization repo field is disabled in personal mode and enabled in
+  organization mode.
+- Organization validation status is clear.
+- Main card board shows local/organization source labels clearly.
+- Cards with Skill dependencies show a small `1 Skill` / `2 Skills` or
+  `1 个技能` / `2 个技能` badge.
+- Card detail shows exact Skill dependencies and registry/install status.
+- Organization panel opens once, shows a loading state immediately, and does
+  not open duplicate windows on repeated clicks.
+- Chinese and English displays show corresponding information with no missing
+  fields.
+- Mouse wheel scrolling feels fast enough for dense card boards.
+
+## Structure Review Gate
+
+After the acceptance tests exist, run a structure review before refactoring.
+
+Record findings in `docs/organization_structure_audit.md`.
+
+Review areas:
+
+- `local_kb/org_*` module boundaries.
+- `local_kb/skill_sharing.py` size and responsibilities.
+- `local_kb/desktop_app.py` UI responsibilities.
+- repeated organization repository fixture setup in tests.
+- reusable e2e test helpers.
+- scripts that duplicate library behavior.
+
+Only apply low-risk cleanup immediately. Larger changes should be listed with:
+
+- problem;
+- affected files;
+- risk;
+- proposed target shape;
+- tests required before/after;
+- whether the cleanup is blocking functional acceptance.
+
+## Done Criteria
+
+Organization mode is functionally accepted when:
+
+- all existing unit/module tests pass;
+- all new e2e acceptance tests pass;
+- installer `--check --json` reports `ok: true`;
+- manual UI checklist has been run and recorded;
+- organization maintenance cleanup has deterministic coverage for duplicate,
+  weak, similar, and Skill-linked candidates;
+- structure audit exists and distinguishes small safe cleanup from larger
+  architectural work.

--- a/docs/organization_mode_plan.md
+++ b/docs/organization_mode_plan.md
@@ -1,11 +1,13 @@
 # Organization Mode Plan
 
-This document records the planned post-v0.1 direction for adding optional
-organization sharing to Khaos Brain.
+This document records the optional organization-sharing design for Khaos Brain
+and the current implementation checkpoints used for the first multi-machine
+test.
 
-`PROJECT_SPEC.md` remains authoritative for v0.1. Organization mode should be
-added as an optional overlay on the same core software, not as a separate
-product fork.
+`PROJECT_SPEC.md` remains authoritative for the core product. Organization mode
+is implemented as an optional overlay on the same core software, not as a
+separate product fork. Sections that still use "should" describe the target
+behavior and review rules that the implementation is being checked against.
 
 ## Product Shape
 
@@ -19,6 +21,38 @@ Use one Khaos Brain codebase.
 
 The first organization source should be a GitHub repository that is mirrored to
 the local machine for fast read-only retrieval.
+
+## Organization Mode Gate
+
+Organization mode should be enabled from Settings, not inferred from the mere
+presence of GitHub on the machine.
+
+The settings flow should be:
+
+1. User chooses organization mode.
+2. UI requires an organization GitHub repository URL.
+3. App clones or fetches the repository into a local mirror.
+4. App validates that the repository is a Khaos Brain organization KB source.
+5. Only after validation succeeds does the app enter organization mode.
+
+Until that validation succeeds, the product stays in personal mode:
+
+- no organization navigation is opened;
+- no organization card source is searched;
+- no GitHub identity discovery is required;
+- no maintainer or advanced maintenance controls are shown.
+
+Validation should check for a minimal repository contract, such as:
+
+- expected `kb/` layout;
+- organization KB manifest, for example `khaos_org_kb.yaml`;
+- supported schema version;
+- organization id;
+- readable `kb/trusted` or `kb/candidates` paths;
+- optional `skills/registry.yaml`.
+
+If validation fails, the UI should show the failure reason and keep the local
+personal KB as the active mode.
 
 ## Source Model
 
@@ -86,6 +120,50 @@ org-kb/
 The organization repository is the canonical shared source. Each machine keeps a
 local mirror for search and browsing.
 
+The organization repository should contain a small manifest so clients can
+distinguish a valid organization KB from an arbitrary GitHub repository. An
+initial manifest could be:
+
+```yaml
+kind: khaos-organization-kb
+schema_version: 1
+organization_id: acme
+kb:
+  trusted_path: kb/trusted
+  candidates_path: kb/candidates
+skills:
+  registry_path: skills/registry.yaml
+```
+
+## Private Sandbox Repository
+
+Organization-mode development should use a private GitHub sandbox repository to
+exercise the real integration path.
+
+The sandbox should be private, but privacy should be defense-in-depth rather
+than the only safety boundary. Content seeded into the sandbox should still be
+safe if accidentally exposed.
+
+Recommended sandbox content:
+
+- real shareable `public` model cards;
+- real reusable engineering or Codex workflow heuristics;
+- sanitized candidate cards generated from local evidence;
+- demo organization Skill registry entries;
+- policy docs for sharing, privacy, and maintenance.
+
+Do not seed the sandbox with:
+
+- private preference cards;
+- user-specific interaction patterns;
+- credentials, tokens, raw machine identifiers, or local absolute paths;
+- customer, employer, or project secrets;
+- raw local observations that have not been sanitized.
+
+This makes the sandbox useful for real testing while preserving the intended
+organization-sharing boundary: organization content should be reusable public
+experience, not personal memory.
+
 ## Identity Model
 
 Do not rely only on a raw machine code or hardware fingerprint.
@@ -132,9 +210,10 @@ submission may include `local_installation_id` for provenance when the user
 allows it. Editable display names and machine labels should be treated as
 optional display metadata, not as stable organization identity.
 
-GitHub identity discovery should be best-effort rather than assumed. The UI
-itself should not depend on Codex knowing a GitHub account. A local backend can
-try, in order:
+GitHub identity discovery should only run after a valid organization source has
+been configured. It should be best-effort rather than assumed. The UI itself
+should not depend on Codex knowing a GitHub account. A local backend can try, in
+order:
 
 1. the configured organization source account;
 2. `gh auth status` / `gh api user` when GitHub CLI is installed and logged in;
@@ -157,9 +236,12 @@ A normal organization user may:
 - configure an organization GitHub KB source;
 - sync and search organization cards locally;
 - browse the organization Skill registry;
-- manually install an approved organization Skill;
+- install approved organization Skills manually or allow policy-approved
+  automatic installation;
 - allow sleep maintenance to generate sanitized organization candidates from
   eligible local model cards and observations;
+- opt in to local organization maintenance runs that inspect the shared
+  organization repo and prepare maintenance branches or pull requests;
 - submit or auto-submit policy-approved organization candidates through a branch
   or pull request;
 - submit Skill candidates when they are supported by card evidence and declared
@@ -171,7 +253,8 @@ A normal organization user should not:
 - directly edit organization trusted cards;
 - automatically upload private local cards, personal preferences, or
   user-specific cards;
-- automatically install organization Skills;
+- automatically install candidate, rejected, unknown, or unpinned organization
+  Skills;
 - overwrite another user's Skill package;
 - promote candidates to trusted organization knowledge.
 
@@ -182,21 +265,42 @@ Organization maintainers may:
 - review imported card candidates;
 - rewrite, split, merge, reject, or promote candidates;
 - mark cards deprecated or superseded;
-- approve organization Skill registry entries;
+- approve or reject card-and-Skill bundles through organization maintenance;
 - assign organization Skill names and versions;
 - maintain privacy and sharing policy docs;
 - merge approved pull requests.
 
-Maintainer authority should come from GitHub permissions, not from a local UI
-toggle alone.
+Separate local maintenance execution from remote authority. A local
+"participate in organization maintenance" switch may run scheduled maintenance,
+prepare reviewed branches, and open pull requests from any opted-in machine.
+GitHub permissions and repository rules decide whether those branches can be
+pushed, merged, or become official organization knowledge. The local switch
+does not bypass protected branches, but it also should not prevent normal users
+from producing maintenance proposals.
 
 Recommended GitHub controls:
 
 - protected default branch;
 - pull request reviews for trusted-card changes;
+- required GitHub Actions checks for organization-maintenance pull requests;
+- repository auto-merge or merge queue for eligible maintenance pull requests;
+- a constrained GitHub-side merge actor, such as `github-actions[bot]`, an
+  organization bot account, or a GitHub App;
 - `CODEOWNERS` or an equivalent maintainer team;
 - restricted write access for registry and trusted-card paths;
 - branch or fork based contribution for normal users.
+
+The merge actor should live in GitHub cloud automation, not on one user's local
+machine. Local machines prepare branches or pull requests. GitHub Actions checks
+the pull request. If all required rules pass, GitHub auto-merge or a restricted
+bot merges it. If checks fail, the pull request stays open for review.
+
+Some private repositories may not support branch protection without a paid
+GitHub plan. In that case, the fallback is still cloud-side automation: run the
+organization KB check workflow on pull requests, then let a restricted
+GitHub-side bot workflow merge only labeled PRs after the check workflow
+completes successfully. This preserves the core boundary that no local machine
+directly merges protected organization knowledge.
 
 The local app may expose an "advanced maintainer tools" mode, but that mode
 should mean "this installation is allowed to run organization-maintenance
@@ -224,6 +328,14 @@ Advanced mode should not directly mutate protected organization content unless
 the GitHub account has the required permission and the repository policy allows
 that path. The safer default is for advanced maintenance to create a branch,
 proposal, or pull request.
+
+For product wording, advanced mode may appear as an administrator or maintainer
+area inside organization mode. Architecturally it is still two checks:
+
+1. organization mode is active because a valid organization KB repo was
+   configured;
+2. maintainer actions are allowed only to the extent the GitHub account and repo
+   rules allow them.
 
 Future implementation should include a coordination mechanism so that only one
 advanced maintenance job acts on the same organization repository state at a
@@ -269,53 +381,275 @@ No organization contribution should silently upload local private knowledge.
 If automatic PR creation is enabled later, it should still target candidate or
 import paths, not trusted organization card paths.
 
-## Skill Sharing
+## Hash-Based Organization Exchange
 
-Skills should be shared through an organization Skill registry, not mixed
-directly into card storage.
+Organization mode should use content hashes for exchange deduplication, not a
+complex shared version tree.
 
-Skill sharing should be card-led. A Skill is strongest as an organization
-candidate when one or more cards already explain when the Skill is useful, what
-problem it solves, what outcome it predicts, and what fallback exists when the
-Skill is missing.
+The organization repository is a stream of reusable cards. Each local
+installation periodically mirrors that stream, searches it, and absorbs only the
+cards that are actually useful locally. Local and organization maintenance then
+use the same existing consolidation logic: similar cards are merged, overloaded
+cards are split, weak cards are rejected, and durable cards are promoted.
 
-Cards may reference organization or local Skills:
+The exchange unit is a normalized `card_exchange_hash`.
+
+- The hash is based on the predictive card content.
+- Local bookkeeping does not affect the hash: adoption metadata, organization
+  proposal metadata, paths, timestamps, source labels, status, scope, confidence,
+  ids, and display translations are ignored.
+- If two cards have the same exchange hash, they are the same exchange payload
+  even if their local ids, paths, display language, or review status differ.
+
+### Download And Use
+
+Organization cards can be mirrored locally as read-only source cards, but they
+do not become local maintenance cards merely because they were visible in search
+or browsing.
+
+Rules:
+
+1. When organization cards are loaded, skip any card whose exchange hash already
+   exists in the local KB. This avoids downloading or displaying exact content
+   duplicates such as a local trusted card and an organization trusted card with
+   the same predictive content.
+2. If an organization card is shown but never used, it stays an organization
+   source card.
+3. When Codex actually uses an organization card, mark that exchange hash as
+   used locally.
+4. If the same hash already exists locally, do not create another adopted file.
+   Treat the existing local card as the local copy.
+5. If the hash does not exist locally, create one local adopted candidate under
+   `kb/candidates/adopted/<org-id>/`.
+6. After use, the card participates in local maintenance as local knowledge. The
+   organization provenance is retained for attribution, but split/merge/rewrite
+   decisions are handled by the normal local maintenance loop.
+
+If the organization later publishes a new card with the same id but different
+content, it has a new exchange hash. The local installation may see it as a new
+organization card. The local maintenance loop can then decide whether it is a
+duplicate, improvement, split candidate, or unrelated card.
+
+### Upload
+
+Local-to-organization contribution uses the same hash rule.
+
+Rules:
+
+1. Before creating an organization outbox item, compute the local card's
+   exchange hash.
+2. Do not export two local cards with the same exchange hash in the same outbox.
+3. Organization repository checks should report duplicate exchange hashes across
+   trusted, candidate, and import paths.
+4. Organization maintenance receives only new exchange payloads and then applies
+   the normal organization maintenance loop: merge duplicates, split overloaded
+   cards, reject weak cards, promote useful cards, and keep Skill bundles tied to
+   card evidence.
+
+This keeps the system simple: hashes prevent exact duplicate exchange, while AI
+maintenance handles semantic similarity, merge, split, and quality review.
+
+## Organization Card Adoption And Feedback Loop
+
+Organization cards should not become globally mutable just because many local
+installations use them. The organization repository remains the shared source,
+while each local installation records its own evidence about whether an
+organization card worked.
+
+When search retrieves an organization card and Codex actually uses it, the local
+installation should either reuse an existing same-hash local card or create one
+local adopted candidate. This keeps the local KB as the active maintenance
+surface and preserves a natural path for later improvement without requiring a
+shared card-version tree.
+
+The rule should be **use on hash**:
+
+1. **Local used copy**
+   - On first real use of an organization card, compute its exchange hash.
+   - If that hash already exists locally, use the existing local card and do not
+     create another duplicate.
+   - If that hash does not exist locally, create one local adopted copy.
+   - The local copy should keep organization provenance such as organization id,
+     source repo, card id, source commit, source path, and source exchange hash.
+
+2. **Usage evidence**
+   - Record local usage against the local card or adopted copy.
+   - Track local hit quality, task contexts, last used time, and use count.
+   - The used copy participates in local-first retrieval on later tasks.
+
+3. **Local maintenance**
+   - Once used, the card is local maintenance material.
+   - If it is similar to existing local knowledge, local sleep maintenance may
+     merge it.
+   - If it mixes several predictive relations, local sleep maintenance may split
+     it.
+   - No special organization-only merge tree is required.
+
+4. **Upstream contribution**
+   - Clean adopted copies are not proposed back.
+   - Locally improved or newly consolidated cards can enter the organization
+     outbox only if their exchange hash has not already been exported in that
+     outbox.
+   - The organization repository then applies its own maintenance loop to the
+     incoming candidates.
+
+This keeps the local KB as the place where actual use is learned and refined,
+while the organization KB receives reviewed new payloads instead of uncontrolled
+direct edits from every machine.
+
+Example local adopted-candidate metadata:
 
 ```yaml
-required_skills:
-  - org.github-release@>=1.2.0
+organization_adoption:
+  organization_id: acme
+  source_entry_id: org-release-checklist
+  source_repo: https://github.com/acme/org-kb
+  source_commit: abc1234
+  source_path: kb/trusted/release-checklist.yaml
+  source_exchange_hash: 6f4c...
+  state: clean
+  hit_count: 3
+  adopted_at: 2026-04-24T08:00:00Z
+  last_used_at: 2026-04-24
+```
+
+## Skill Sharing
+
+Skills should be shared through organization maintenance, not as standalone
+files that become trusted merely because someone uploaded them.
+
+Skill sharing should be card-led. The review unit is a bundle:
+
+- one or more candidate cards;
+- required or recommended Skill candidates;
+- dependency metadata linking cards to Skills;
+- task evidence showing when the Skill helped, failed, replaced a fallback, or
+  should be invoked earlier.
+
+A Skill is strongest as an organization candidate when cards already explain
+when it is useful, what problem it solves, what outcome it predicts, and what
+fallback exists when the Skill is missing.
+
+Cards may reference organization or local Skills. In the first implementation,
+Skills travel as card-bound bundles rather than as free-floating organization
+assets:
+
+```yaml
+skill_dependencies:
+  - bundle_id: skill-bundle-20260424T213000Z-a8f3
+    local_name: github-helper
+    requirement: required
+    content_hash: sha256:...
+    version_time: 2026-04-24T21:30:00Z
 fallback:
   guidance: Use the generic GitHub release workflow if the Skill is not installed.
 ```
 
-Skill registry entries should include:
+The `bundle_id` is the Skill lineage. The `content_hash` is the exact version.
+The latest approved version for a `bundle_id` is selected by `version_time`.
+Imported organization Skill bundles are read-only locally. Only the original
+author may update the same `bundle_id`; non-author changes must fork to a new
+`bundle_id`.
+
+Skill registry entries or bundle metadata should include:
 
 ```yaml
-id: org.github-release
-version: 1.2.0
-owner: platform-team
-submitted_by: alice
+bundle_id: skill-bundle-20260424T213000Z-a8f3
+local_name: github-helper
+original_author: alice
 status: approved
-source_repo: https://github.com/example-org/org-skills
+content_hash: sha256:...
+version_time: 2026-04-24T21:30:00Z
+readonly_when_imported: true
+update_policy: original_author_only
 ```
 
-The first implementation should browse the registry and support manual
-installation. Automatic Skill installation should wait for a later security
-design.
+Use three Skill review states:
+
+- `candidate`: uploaded or generated, but not reviewed yet;
+- `approved`: reviewed together with supporting cards and evidence, eligible
+  for search and policy-approved automatic installation;
+- `rejected`: reviewed and not recommended; kept only as an audit signal so the
+  same weak Skill/card bundle does not recur silently.
+
+Do not make `blocked` or `deprecated` first-pass states unless later operation
+shows they are needed. Rejected bundles are enough for the initial review loop.
+
+Approved Skill auto-installation is allowed when local policy permits it and
+the bundle entry is pinned to a version time and content hash. Candidate or
+rejected Skills must not be silently installed.
 
 Local Skill submission should normally follow card dependency evidence:
 
 1. a local card or observation records successful use of a Skill;
 2. maintenance detects that the card depends on that Skill;
-3. maintenance checks whether the Skill is already in the organization registry;
-4. if missing, maintenance proposes a Skill candidate alongside the card
-   candidate;
-5. maintainers review the card and Skill together.
+3. maintenance checks whether the Skill bundle already has a `bundle_id`;
+4. if missing, maintenance proposes a new card-bound Skill bundle alongside the
+   card candidate;
+5. organization maintenance reviews the card, Skill, dependency link, and
+   evidence together;
+6. approved bundles enter the official organization KB; rejected bundles stay
+   out of the official search/install path.
+
+Local sleep maintenance should consolidate imported organization Skills by
+`bundle_id`, keep only the latest approved local copy by `version_time`, and
+preserve the source-card references explaining why the Skill exists. Uploading
+any card that depends on a Skill should attach the local latest version for
+that `bundle_id`, not an older copy carried by the card.
 
 If a local Skill is frequently used but has no supporting card, maintenance
 should create or request a Skill-use observation first. The local KB workflow
 should continue strengthening the rule that meaningful Skill use, especially
 new Skill use, is written back as KB evidence.
+
+## Organization Sleep And Maintenance
+
+Organization maintenance is the shared-library equivalent of local sleep/dream.
+Its purpose is to turn many users' candidate uploads into a smaller, reviewed,
+auditable organization knowledge base.
+
+Inputs:
+
+- imported candidate cards from local outboxes;
+- imported Skill candidates;
+- dependency metadata linking cards and Skills;
+- local adoption feedback from organization cards;
+- task evidence and Skill-use observations;
+- current organization approved cards and approved Skill registry entries.
+
+Organization maintenance should review bundles, not isolated files. A bundle can
+contain a card, one or more Skills, and evidence. The maintenance run decides
+whether the whole bundle should become organization knowledge, stay candidate,
+or be rejected.
+
+Core maintenance actions:
+
+- deduplicate similar cards from different contributors;
+- merge compatible cards and split overloaded cards;
+- rewrite candidates into organization-neutral wording;
+- reject weak, private, unsafe, or over-specific candidates;
+- approve card-and-Skill bundles together when evidence supports them;
+- pin approved Skill versions and content hashes;
+- write rejected review records so similar weak submissions can be recognized;
+- check that every approved Skill has supporting card evidence;
+- check that every approved card dependency points to an approved Skill or a
+  documented fallback;
+- scan for private data, local paths, credentials, and unsafe Skill behavior.
+
+Participation model:
+
+- Any opted-in machine may run local organization maintenance and prepare a
+  maintenance branch or pull request.
+- GitHub permissions and protected branch rules decide whether the maintenance
+  branch is accepted into the organization repo.
+- The local "participate in organization maintenance" switch schedules work; it
+  does not grant merge authority.
+
+Machines that participate in organization maintenance should install a local
+organization-review Skill. That Skill teaches Codex how to audit other Skills,
+card dependencies, evidence quality, privacy boundaries, and install safety.
+Without that Skill, a machine can still submit candidates, but it should not run
+full organization maintenance reviews.
 
 ## UI Information Architecture
 
@@ -355,9 +689,10 @@ The important distinction is:
 - `Contributions` answers "what can I submit or what have I submitted?"
 - `Maintenance` answers "what automated upkeep is running or proposed?"
 
-When organization mode is not configured, organization-specific navigation
-items should be hidden or shown as disabled setup entry points. The personal
-local flow should stay simple.
+When organization mode is not configured or the organization repo has not passed
+validation, organization-specific navigation items should be hidden or shown only
+as disabled setup entry points. The personal local flow should stay simple. The
+full organization UI should open only after the organization source is validated.
 
 Search and card detail UI must show:
 
@@ -381,11 +716,13 @@ trust level, contributor, and required Skill status.
 Organization support should add these UI surfaces:
 
 1. Organization settings
+   - Personal mode / organization mode selector.
    - GitHub repository URL input.
-   - Connection check.
+   - Repository validation check for the Khaos Brain organization KB manifest
+     and layout.
    - Local mirror path.
-   - Authenticated GitHub account.
-   - Current permission level.
+   - Authenticated GitHub account after organization source validation.
+   - Current permission level after account detection.
 
 2. Search results
    - Source badge.
@@ -393,22 +730,35 @@ Organization support should add these UI surfaces:
    - Trust level.
    - Required Skill status.
    - Local/private versus organization/shared distinction.
+   - Exchange-hash status for organization cards when available, such as
+     already local, new organization payload, or used locally.
 
-3. Contribution center
-   - Select local cards, observations, and Skills.
+3. Local exchange and contribution center
+   - Show organization cards that were used locally.
+   - Show whether a used organization hash reused an existing local card or
+     created a local adopted candidate.
+   - Show whether the local card is clean, diverged, feedback-ready, or already
+     exported.
+   - Show generated local outbox candidates from cards, observations, and
+     Skills.
    - Show sanitized preview before upload.
    - Show contributor metadata.
    - Create branch or pull request.
 
 4. Organization Skill registry
-   - Browse approved and candidate Skills.
+   - Browse candidate, approved, and rejected Skills.
    - Show owner, version, status, and install state.
-   - Install approved Skills manually.
+   - Install approved Skills manually or automatically according to local
+     policy.
+   - Never silently install candidate or rejected Skills.
 
-5. Maintainer tools
-   - Review candidate cards and Skill proposals.
-   - Promote, reject, split, merge, or deprecate.
-   - Require GitHub maintainer permission for remote write actions.
+5. Organization maintenance tools
+   - Review card-and-Skill bundles.
+   - Promote, reject, split, merge, or supersede through reviewed proposals.
+   - Require the local organization-review Skill for full automated review.
+   - Let any opted-in machine prepare maintenance branches or PRs.
+   - Require GitHub maintainer permission only for merge or protected remote
+     write actions.
 
 ## Implementation Phases
 
@@ -416,14 +766,188 @@ Do not implement all of organization mode at once.
 
 1. Add organization source configuration and local read-only sync.
 2. Add multi-source retrieval and source badges.
-3. Add automatic organization candidate generation for eligible local model
+3. Add hash-based organization exchange: mirror read-only organization cards,
+   hide exact content duplicates already present locally, and create local
+   adopted copies only when a used organization hash is not already local.
+4. Add automatic organization candidate generation for eligible local model
    cards and observations.
-4. Add read-only Skill registry browsing.
-5. Add card-led Skill candidate generation and manual Skill installation from
-   approved registry entries.
-6. Add GitHub pull request contribution for generated card and Skill
+5. Add read-only Skill registry browsing.
+6. Add card-led Skill candidate generation and policy-approved installation
+   from approved registry entries.
+7. Add GitHub pull request contribution for generated card and Skill
    candidates.
-7. Add maintainer review UI and GitHub-permission-gated write actions.
+8. Add organization-review Skill and local organization maintenance proposals.
+9. Add GitHub cloud auto-check, auto-merge, and protected write rules.
+
+## End-To-End Master Plan
+
+This is the canonical order for turning the personal KB into an organization KB.
+It ties the sandbox repository, first local machine, simulated second user,
+Skill review, maintenance workflow, and UI rollout into one path. After every
+stage, rerun the strongest practical personal-mode and organization-mode checks
+before continuing.
+
+1. **Freeze the personal baseline**
+   - Verify current local search, UI browsing, feedback/history writes, sleep
+     inputs, and existing tests.
+   - Record that no organization source is configured and the product behaves
+     exactly as a personal KB.
+   - Checkpoint: personal mode can be used with no GitHub repo, no organization
+     UI, and no source/provenance metadata required on old cards.
+
+2. **Prepare the private GitHub sandbox**
+   - Use one private repository as the organization KB sandbox.
+   - Add `khaos_org_kb.yaml`, `kb/trusted`, `kb/candidates`,
+     `skills/registry.yaml`, `skills/candidates`, and policy docs.
+   - Seed it with real shareable public/sanitized cards and demo Skill registry
+     entries, never private preferences or raw local observations.
+   - Checkpoint: a clean clone validates as a Khaos Brain organization KB.
+
+3. **Add the organization mode gate**
+   - Add Settings fields for personal/organization mode, GitHub repo URL, local
+     mirror path, validation status, and organization id.
+   - Organization UI opens only after the repo URL validates against the
+     manifest and required layout.
+   - Checkpoint: invalid or missing repo URL leaves the app in personal mode.
+
+4. **Mirror the organization source locally**
+   - Clone or fetch the sandbox into a local mirror under app-managed storage.
+   - Store last sync commit, sync time, validation result, and read-only status.
+   - Discover GitHub identity only after the organization source is valid.
+   - Checkpoint: the same machine can switch personal -> organization ->
+     personal without losing local KB behavior.
+
+5. **Add source and provenance everywhere**
+   - Treat old local cards as local by default.
+   - Add source labels for local private/public/candidate and organization
+     trusted/candidate/Skill.
+   - Carry contributor, organization id, source repo, and source commit on
+     organization cards.
+   - Checkpoint: every search result and card detail can explain where the card
+     came from.
+
+6. **Implement multi-source retrieval and UI filtering**
+   - Search local first, then organization cards.
+   - Add source filters and badges for local, organization, trusted, candidate,
+     contributor, and required Skill status.
+   - Keep organization mirror cards read-only.
+   - Checkpoint: disabling organization mode hides organization results and
+     restores the personal-only UI.
+
+7. **Implement hash-based local use**
+   - When an organization card is actually used, compute its exchange hash.
+   - If that hash already exists locally or was already absorbed/exported by
+     this installation, reuse or suppress it instead of creating another file.
+   - If the hash is new locally, create one adopted candidate and record source
+     provenance plus `source_exchange_hash`.
+   - Checkpoint: merely viewing a result does not copy it; real use either
+     reuses an existing local same-hash card or creates one adopted candidate.
+
+8. **Track local divergence and feedback readiness**
+   - Mark adopted cards as `clean`, `diverged`, `feedback_ready`, or
+     `locally_rejected`.
+   - Clean adopted copies are not proposed back to the organization.
+   - Diverged or feedback-ready copies can become organization update
+     candidates.
+   - Checkpoint: a hit-count-only copy stays local; a meaningfully edited copy
+     can enter the outbox.
+
+9. **Generate automatic organization candidates**
+   - Extend sleep maintenance to produce a local organization outbox.
+   - Include eligible local model/heuristic cards, sanitized observations,
+     Skill-use evidence, and locally improved used organization cards.
+   - Exclude personal preferences, user-specific memories, credentials, raw
+     machine identifiers, local absolute paths, and sensitive provenance.
+   - Skip cards whose exchange hash was already exported by this installation,
+     already exists in the organization mirror, or duplicates another outbox
+     item.
+   - Checkpoint: the outbox is generated locally and writes nothing to GitHub.
+
+10. **Contribute candidates through GitHub branches or PRs**
+    - Convert outbox items into branch changes under `kb/candidates`,
+      `kb/imports`, or `skills/candidates`.
+    - Include provenance and a sanitization summary.
+    - Never write directly to `kb/trusted`.
+    - Checkpoint: one generated candidate can be pushed or prepared for the
+      sandbox as a reviewable GitHub change.
+
+11. **Configure GitHub cloud auto-check and auto-merge**
+    - Add GitHub Actions workflows for organization-maintenance pull requests.
+    - Required checks should cover schema and manifest validity, path policy,
+      private-data scans, local path and credential scans, duplicate/update
+      risk, Skill registry states, approved Skill version/hash pinning, and
+      card-and-Skill bundle evidence.
+    - Enable repository auto-merge or merge queue for eligible maintenance pull
+      requests.
+    - Use a constrained GitHub-side merge actor, such as `github-actions[bot]`,
+      an organization bot account, or a GitHub App.
+    - Local machines should not directly push to protected branches.
+    - Checkpoint: a low-risk maintenance PR with the right label and passing
+      checks merges automatically; a failing PR stays open and does not update
+      the organization KB.
+
+12. **Simulate a second local user or second machine**
+    - Create a second local install profile or workspace mirror with a different
+      local installation id and machine label.
+    - Point both profiles at the same private sandbox repo.
+    - Verify both can sync, search, use organization cards, and create separate
+      local adopted copies.
+    - Checkpoint: two local profiles can share organization knowledge through
+      GitHub while keeping their local KBs and local evidence separate.
+
+13. **Test cross-user feedback flow**
+    - Let profile A contribute a candidate.
+    - Let profile B sync it, use it, adopt it locally, and optionally diverge it.
+    - Verify clean adoption from profile B does not flow back, while a real
+      refinement can become a feedback candidate.
+    - Checkpoint: organization cards improve through reviewed feedback, not
+      uncontrolled direct edits from every machine.
+
+14. **Add card-led Skill registry workflow**
+    - Read and display `skills/registry.yaml`.
+    - Use only three Skill states: `candidate`, `approved`, and `rejected`.
+    - Link Skill candidates to the cards and evidence that justify them.
+    - Allow automatic install only for approved, version-pinned, hash-pinned
+      Skills when local policy permits.
+    - Checkpoint: candidate/rejected/unknown/unpinned Skills cannot be silently
+      installed.
+
+15. **Create and install the organization-review Skill**
+    - Define how Codex reviews other Skills, card dependencies, evidence
+      quality, privacy, unsafe behavior, and install safety.
+    - Require this Skill before a machine runs full automated organization
+      maintenance.
+    - Checkpoint: machines without the organization-review Skill can submit
+      candidates, but cannot run full review automation.
+
+16. **Add organization sleep and maintenance**
+    - Add a local "participate in organization maintenance" switch.
+    - Review card-and-Skill bundles, not isolated files.
+    - Let any opted-in machine prepare maintenance branches or PRs.
+    - Let GitHub permissions and branch rules decide what becomes official.
+    - Checkpoint: local maintenance can propose merges, splits, approvals, and
+      rejections without bypassing GitHub protected branches.
+
+17. **Wire the final organization UI**
+    - Settings: personal/organization mode, repo validation, sync status,
+      identity, local maintenance participation.
+    - Search: source badges, owner/contributor, trust state, Skill status,
+      adoption state.
+    - Contributions: outbox, sanitized preview, branch/PR status.
+    - Skills: candidate/approved/rejected, install state, dependency evidence.
+    - Maintenance: bundle review, proposed changes, run history.
+    - Checkpoint: a user can understand whether an item is local or
+      organization, who contributed it, whether it is trusted, and what action
+      is safe.
+
+18. **Harden with multi-machine regression tests**
+    - Re-run personal mode with no organization settings.
+    - Re-run one-machine organization sync and search.
+    - Re-run two-profile adoption and contribution.
+    - Re-run Skill registry and approved-Skill install policy checks.
+    - Re-run organization maintenance proposal checks.
+    - Checkpoint: organization mode is an optional overlay on the personal KB,
+      not a forked product and not a direct-write shared database.
 
 ## Execution Roadmap
 
@@ -492,8 +1016,10 @@ The config should be local-machine state. It should not be committed into a
 public repository with user secrets or machine-specific paths.
 
 Done when: the app can validate a GitHub repo URL, fetch through local GitHub
-credentials when available, show the configured or detected account, and
-remember the local mirror location.
+credentials when available, verify that the repo is a Khaos Brain organization
+KB source, show the configured or detected account only after validation, and
+remember the local mirror location. If validation fails, the app remains in
+personal mode.
 
 ### Phase 3: Read-Only Organization Sync
 
@@ -524,13 +1050,35 @@ blurring ownership.
 Done when: the user can see which result came from local private memory, local
 public memory, organization trusted knowledge, or organization candidates.
 
-### Phase 5: Automatic Candidate Outbox
+### Phase 5: Organization Card Usage Feedback
+
+Goal: preserve local learning from organization cards without letting every
+machine directly edit organization truth.
+
+- Compute a normalized exchange hash when an organization card is actually used.
+- Reuse an existing same-hash local card when one exists; otherwise create one
+  local adopted candidate.
+- Store organization provenance on the adopted candidate when one is created,
+  including organization id, card id, source repo, source commit, source path,
+  and source exchange hash.
+- Record local observations against the reused local card or adopted candidate.
+- Let normal local maintenance narrow, update, split, merge, supersede, or
+  connect the used card to a Skill after it becomes local maintenance material.
+- Keep the organization card read-only in the local mirror.
+
+Done when: using an organization card either reuses an existing same-hash local
+card or creates one adopted candidate that participates in local-first
+retrieval and can later produce organization feedback.
+
+### Phase 6: Automatic Candidate Outbox
 
 Goal: let sleep maintenance automatically prepare organization candidates from
 eligible local knowledge.
 
 - Add an organization outbox for generated card and Skill candidates.
 - Let sleep maintenance scan local cards, observations, and Skill-use evidence.
+- Include evidence from used organization cards after they have entered local
+  maintenance.
 - Generate sanitized organization candidates only from reusable models or
   heuristics, not personal preferences.
 - Compare candidates against existing organization cards and propose updates,
@@ -542,52 +1090,70 @@ eligible local knowledge.
 Done when: sleep maintenance can produce a local organization candidate outbox
 from eligible cards without exposing unrelated private cards.
 
-### Phase 6: Card-Led Organization Skill Registry
+### Phase 7: Card-Led Organization Skill Registry
 
-Goal: share reusable capabilities separately from predictive cards, but use card
-evidence to decide which Skills are worth proposing.
+Goal: share reusable capabilities through card-and-Skill bundles, with
+organization maintenance deciding which bundles become approved organization
+knowledge.
 
 - Add read-only browsing for `skills/registry.yaml`.
 - Show Skill owner, version, approval status, source repository, and local
   install state.
 - Let cards reference required or recommended organization Skills.
 - Detect local Skill dependencies from cards and observations.
-- Generate Skill candidates when a generated organization card depends on a
-  Skill missing from the registry.
+- Generate card-bound Skill bundle candidates when a generated organization
+  card depends on a Skill missing from the approved bundle set.
 - Require supporting card evidence for normal Skill submission.
-- Support manual installation of approved Skills after the registry browsing
-  path is reliable.
-- Defer automatic Skill installation until there is a stronger security design.
+- Group card-bound Skill bundles by `bundle_id`; use `content_hash` for exact
+  versions and `version_time` to select the latest approved version.
+- Keep imported organization Skills read-only locally; original authors may
+  update the same `bundle_id`, while non-author changes fork to a new
+  `bundle_id`.
+- Use three review states: `candidate`, `approved`, and `rejected`.
+- Support policy-approved automatic installation of approved, version-time
+  pinned, hash-pinned Skill bundles.
+- Never silently install candidate or rejected Skills.
+- Add or install an organization-review Skill before allowing a machine to run
+  full organization maintenance reviews.
 
 Done when: a generated organization card can carry its Skill dependency, and a
-missing dependency can become a linked Skill candidate for maintainer review.
+missing dependency can become a linked Skill candidate for bundle review.
 
-### Phase 7: Maintainer Review and Advanced Maintenance
+### Phase 8: Maintainer Review and Advanced Maintenance
 
-Goal: support organization cleanup without making every local machine a direct
-writer to shared truth.
+Goal: support organization cleanup as an opt-in local automation that prepares
+reviewable organization maintenance proposals.
 
-- Add maintainer UI for reviewing card and Skill candidates.
-- Gate trusted-card writes through GitHub permissions and protected-branch
-  rules.
-- Let advanced maintenance mode run scheduled scans and prepare review PRs.
+- Add organization maintenance UI for reviewing card-and-Skill bundles.
+- Let any opted-in machine run scheduled organization maintenance scans and
+  prepare review branches or pull requests.
+- Gate merge into official organization knowledge through GitHub permissions and
+  protected-branch rules.
 - Let advanced maintenance detect duplicate cards, stale cards, superseded
   cards, and local evidence that should update an existing organization card
   rather than create a new one.
+- Let organization maintenance approve or reject bundles using the three-state
+  model, and record rejected reviews as audit signals.
 - Coordinate maintenance through visible branches, pull requests, and run files
   before considering any separate server.
 
 Done when: maintainers can promote, reject, merge, split, or deprecate
-organization candidates through a review flow that respects GitHub repository
+organization candidates through a review flow, while normal opted-in machines
+can still prepare maintenance proposals without bypassing GitHub repository
 permissions.
 
-### Phase 8: Rollout and Hardening
+### Phase 9: Rollout and Hardening
 
 Goal: validate the organization model with real multi-machine use before adding
 more automation.
 
-- Test with one private organization repo and two or three machines.
+- Test with one private organization sandbox repo and two or three machines.
+- Seed the sandbox with real shareable public/sanitized cards, not only fake demo
+  cards.
 - Verify that source labels remain clear in UI and retrieval output.
+- Verify that organization card usage either reuses same-hash local knowledge
+  or creates local adopted-candidate evidence without mutating organization
+  trusted cards directly.
 - Verify that private local cards and personal preferences never upload as raw
   cards; only sanitized, policy-eligible organization candidates may leave the
   local machine.
@@ -600,10 +1166,378 @@ more automation.
 Done when: the organization mode works as an optional, reviewable overlay on
 the personal KB instead of becoming a separate product.
 
+## Detailed Build Plan
+
+This is the concrete implementation order to follow when organization-mode work
+begins. The plan intentionally starts with a private sandbox and read-only
+integration before contribution, Skill installation, or maintainer automation.
+
+### Step 1: Create The Private Sandbox Repository
+
+Create a private GitHub repository such as `khaos-org-kb-sandbox`.
+
+Required initial files:
+
+```text
+khaos_org_kb.yaml
+kb/
+  trusted/
+  candidates/
+skills/
+  registry.yaml
+  candidates/
+docs/
+  sharing-policy.md
+  privacy-policy.md
+  maintainer-policy.md
+```
+
+Seed the sandbox with real shareable cards, not only fake demo cards. Use
+`public` model cards, generic engineering heuristics, generic Codex workflow
+cards, and sanitized candidates. Do not seed private preference cards,
+user-specific interaction cards, credentials, local machine paths, or raw
+unsanitized observations.
+
+Done when: the private repo can be cloned manually and contains a valid
+`khaos_org_kb.yaml` manifest plus at least one trusted card, one candidate card,
+and one Skill registry entry.
+
+### Step 2: Preserve The Personal-Mode Baseline
+
+Before adding organization behavior, verify current personal mode.
+
+- Run the desktop check.
+- Run local search.
+- Run feedback/history write.
+- Confirm older cards with no organization metadata still load as local cards.
+- Confirm the UI still opens without any organization settings.
+
+Done when: personal KB behavior is unchanged and has a baseline check that can
+be rerun after every organization-mode phase.
+
+### Step 3: Add Settings Mode Selection
+
+Add local settings for:
+
+- `mode: personal | organization`;
+- organization GitHub repo URL;
+- local mirror path;
+- organization id after validation;
+- last validation status and message.
+
+The UI should expose a personal/organization selector in Settings. Selecting
+organization mode should require a GitHub repo URL, but it should not open the
+organization UI until repo validation succeeds.
+
+Done when: Settings can save personal mode, attempt organization mode, and fall
+back to personal mode if the repo URL is missing or invalid.
+
+### Step 4: Validate And Mirror The Organization Repo
+
+Add organization-source tooling that can:
+
+- clone or fetch the configured GitHub repo into a local mirror;
+- read `khaos_org_kb.yaml`;
+- validate `kind`, `schema_version`, `organization_id`, `kb/trusted`,
+  `kb/candidates`, and optional `skills/registry.yaml`;
+- record sync status, last fetched commit, and last sync time.
+
+GitHub identity discovery should happen only after this validation passes.
+
+Done when: the private sandbox repo can be configured in Settings, mirrored
+locally, validated as a Khaos Brain organization KB, and used to activate
+organization mode.
+
+### Step 5: Add Source And Provenance Metadata
+
+Extend loaded card summaries with source metadata without requiring old local
+cards to be rewritten.
+
+Minimum source labels:
+
+- `local/private`;
+- `local/public`;
+- `local/candidate`;
+- `org/<org-id>/trusted`;
+- `org/<org-id>/candidate`;
+- `org/<org-id>/skill`.
+
+Organization cards should also carry source repo, source commit, organization
+id, contributor when available, and read-only status.
+
+Done when: UI payloads and search payloads can tell whether every card is local
+or organization, and old local cards default to `local`.
+
+### Step 6: Add Multi-Source Search And Browsing
+
+Load local entries and organization mirror entries as separate sources.
+
+- Local results rank first by default.
+- Organization results appear after local results unless a filter asks for org
+  only.
+- Search and route browsing show source badges.
+- Organization cards are read-only in the mirror.
+- Organization UI appears only after a validated source is active.
+
+Done when: searching a term can return both local and sandbox organization
+cards with clear source labels, and disabling organization mode returns to the
+personal UI.
+
+### Step 7: Add Hash-Based Use And Local Absorption
+
+When an organization card is actually used, compute its normalized exchange
+hash before creating any local file.
+
+Rules:
+
+- Do not copy cards that were merely shown in search results but not used.
+- If the exchange hash already exists anywhere in the local KB, reuse that
+  local card and do not create another adopted copy.
+- If the exchange hash is new locally, create one local adopted copy under
+  `kb/candidates/adopted/<org-id>/`.
+- On later use of the same adopted copy, update usage metadata instead of
+  creating another duplicate.
+- Used organization content participates in local-first retrieval and local
+  sleep maintenance.
+- Track `hit_count`, `last_used_at`, `source_commit`, `source_path`,
+  `source_exchange_hash`, and local evidence ids when an adopted file exists.
+
+Done when: using a sandbox organization card either reuses an existing same-hash
+local card or creates one adopted copy, and exact same-hash organization cards
+are no longer shown as duplicate local/organization cards.
+
+### Step 8: Track Clean, Diverged, And Feedback States
+
+A local adopted copy should have a sync state:
+
+- `clean`: copied from organization and only usage metadata changed;
+- `diverged`: predictive content, route, wording, Skill dependency, or scope was
+  changed locally;
+- `feedback_ready`: local change appears reusable and can be proposed back;
+- `locally_rejected`: local evidence suggests the organization card is weak,
+  stale, or not applicable.
+
+Automatic organization contribution should ignore clean adopted copies. Only
+diverged or feedback-ready copies should be considered for organization
+candidate updates.
+
+Done when: a copied org card with only `hit_count` changes is not proposed back,
+while a copied org card with content changes can enter the feedback outbox.
+
+### Step 9: Add Organization Skill Registry And Review States
+
+Read `skills/registry.yaml` from the organization mirror.
+
+- Show candidate, approved, and rejected Skills.
+- Show owner, version, status, source repo, and local install state.
+- Show required or recommended Skill status on cards.
+- Display card-and-Skill bundle links so reviewers can see which cards provide
+  evidence for a Skill.
+- Allow policy-approved automatic installation only for approved Skills that are
+  version-pinned and hash-pinned.
+- Do not automatically install candidate or rejected Skills.
+
+Done when: organization cards can display missing, candidate, approved, or
+rejected Skill dependencies from the sandbox registry, and approved Skills have
+enough metadata for safe policy-based installation.
+
+### Step 10: Add Automatic Candidate Outbox
+
+Extend sleep maintenance to generate an organization outbox.
+
+Inputs:
+
+- eligible local `model` and `heuristic` cards;
+- sanitized observations;
+- diverged adopted copies from organization cards;
+- Skill-use evidence.
+
+Filters:
+
+- exclude private preferences by default;
+- exclude user-specific cards;
+- exclude credentials, local paths, machine identifiers, and sensitive
+  provenance;
+- compare exchange hashes against local outbox items and current organization
+  cards before proposing duplicates.
+
+Outputs:
+
+- new organization candidate;
+- update existing organization card;
+- merge/split proposal;
+- supersede/deprecate proposal;
+- linked Skill candidate when needed;
+- card-and-Skill bundle proposal when a candidate card depends on a Skill.
+
+Done when: sleep can generate a local organization outbox without writing to the
+remote repository.
+
+### Step 11: Add Branch And Pull Request Contribution
+
+Convert outbox items into GitHub contribution branches or forks.
+
+- Write only to `kb/candidates`, `kb/imports`, or `skills/candidates`.
+- Include provenance and sanitization summary.
+- Preserve links to local evidence ids.
+- Prepare or open a PR.
+- Never write directly to `kb/trusted`.
+
+Done when: one generated candidate can be pushed to the private sandbox as a PR
+against candidate/import paths.
+
+### Step 12: Add GitHub Cloud Auto-Check And Auto-Merge
+
+Configure the organization GitHub repository so maintenance can close the loop
+without a local machine acting as the merger.
+
+Required repository setup:
+
+- enable pull requests and repository auto-merge or merge queue;
+- protect the default branch;
+- require GitHub Actions checks before protected paths can merge;
+- configure a constrained merge actor, such as `github-actions[bot]`, an
+  organization bot account, or a GitHub App;
+- restrict direct pushes to trusted paths.
+
+Required checks for organization-maintenance pull requests:
+
+- manifest and schema validation;
+- allowed-path validation;
+- private data, credential, local path, and machine identifier scan;
+- duplicate, merge, and supersession sanity check;
+- card-and-Skill bundle evidence check;
+- Skill registry state check using only `candidate`, `approved`, and
+  `rejected`;
+- approved Skill version and content-hash pinning check;
+- organization-review Skill requirement for full maintenance proposals.
+
+Done when: a labeled low-risk maintenance PR can merge automatically after all
+checks pass, while a PR that fails any required rule remains unmerged.
+
+### Step 13: Add Organization Sleep And Maintenance Workflows
+
+Add a local "participate in organization maintenance" mode. This is an
+automation switch, not a merge-permission switch.
+
+Organization maintenance workflows should support:
+
+- install or require the local organization-review Skill before full automated
+  review;
+- review card-and-Skill bundles;
+- merge, split, reject, supersede, or deprecate;
+- compare local feedback against current organization card versions;
+- approve or reject bundles using `candidate`, `approved`, and `rejected`;
+- create reviewed branches or PRs for official organization KB changes.
+
+Any opted-in machine can run the review automation and prepare a branch or PR.
+GitHub permissions and repository rules decide whether that work is merged.
+The local switch should not grant merge authority, but it should not block
+ordinary contributors from producing maintenance proposals.
+
+Done when: a machine with organization mode enabled and the organization-review
+Skill installed can generate a reviewable maintenance proposal for sandbox
+candidates without bypassing GitHub protected branch rules.
+
+### Step 14: Multi-Machine Rollout Test
+
+Test with at least two local installations or two machine profiles against the
+same private sandbox repo.
+
+Verify:
+
+- both machines can validate and mirror the repo;
+- each machine reuses same-hash local cards or creates its own local adopted
+  copies only for new used organization hashes;
+- clean adopted copies do not get proposed back;
+- diverged adopted copies can become feedback candidates;
+- GitHub identity is stable across machines for the same account;
+- organization source labels stay clear in UI and search;
+- private preferences never leave local storage.
+
+Done when: organization mode behaves as a shared read source plus reviewed
+feedback loop, not as uncontrolled multi-user writes.
+
+## Current Implementation Status
+
+As of the first organization-mode implementation pass, the local codebase has
+the read-only and local-feedback foundations in place:
+
+- desktop settings support personal mode by default and organization mode only
+  after a GitHub/local repo mirror validates against `khaos_org_kb.yaml`;
+- organization source validation, clone/fetch, and manifest checks live in
+  `local_kb/org_sources.py`;
+- search can merge local entries with read-only organization mirror entries,
+  preserving local-first behavior, source/provenance metadata, and hash-based
+  suppression of exact organization cards already present locally;
+- route browsing, all-cards browsing, status/type filters, and search can merge
+  local entries with organization mirror entries after organization mode is
+  validated, while exact same-hash local duplicates are collapsed for browsing;
+- the desktop UI exposes Local/Organization source filters only when a valid
+  organization source is active;
+- cards and details expose local/organization source labels, author fallback,
+  read-only state, and card-declared Skill dependency review status;
+- the desktop footer exposes a lightweight Organization status panel with
+  source count, Skill registry counts, maintenance availability, and current
+  maintenance recommendations;
+- organization cards are absorbed locally on use by exchange hash: an existing
+  same-hash local card is reused, otherwise one adopted candidate is created
+  with `clean`, `diverged`, `feedback_ready`, and `locally_rejected` state
+  support;
+- automatic organization outbox generation filters to shareable model/heuristic
+  cards, excludes private/preferences, skips duplicate exchange hashes within
+  the outbox, and does not send clean adopted copies back;
+- card-led Skill dependencies are attached to outbox proposals as card-bound
+  Skill bundles with `bundle_id`, `content_hash`, `version_time`,
+  `original_author`, and read-only import policy; approved/candidate/rejected
+  status plus policy-based auto-install eligibility are surfaced in UI payloads;
+  a safe script-level installer can install only approved, version-time pinned,
+  hash-verified Skill bundles and refuses candidate/rejected/unknown/unpinned
+  Skills;
+- the local organization maintenance switch is now represented as
+  "participate in organization maintenance"; it enables local maintenance
+  proposal automation without granting GitHub merge authority;
+- local maintainer and contribution helpers can inspect an organization mirror
+  and prepare a local import branch under `kb/imports/<contributor>/`.
+- a private sandbox organization repository exists and has been seeded with
+  trusted cards, candidate cards, a Skill registry, GitHub Actions checks, and
+  auto-merge workflow templates;
+- GitHub cloud auto-check and auto-merge workflow templates are installed in
+  the private sandbox repository, with required checks driven by
+  `scripts/kb_org_check.py` locally and a vendored
+  `.github/scripts/org_kb_check.py` checker inside the organization repo;
+- GitHub API configuration successfully enabled the repository update step, but
+  branch protection on the private sandbox returned GitHub 403 unless the repo
+  is public or the account is upgraded; the sandbox therefore uses the
+  GitHub-side workflow fallback that merges labeled PRs after the organization
+  check workflow succeeds;
+- live GitHub smoke test PRs verified the cloud loop: the organization KB check
+  workflow passed, the PRs carried `org-kb:auto-merge`, and
+  `github-actions[bot]` merged them automatically.
+
+Current local script entry points:
+
+```powershell
+python scripts\kb_org_outbox.py --repo-root . --organization-id <org-id> --dry-run
+python scripts\kb_org_maintainer.py --repo-root . --org-root <local-org-mirror>
+python scripts\kb_org_contribute.py --repo-root . --org-root <local-org-mirror> --organization-id <org-id> --contributor-id <github-or-machine-id>
+python scripts\kb_org_check.py --org-root <local-org-mirror> --changed-file kb/candidates/example.yaml --enforce-low-risk
+python scripts\kb_org_install_skill.py --org-root <local-org-mirror> --skill-id <approved-skill-id> --allow-auto-policy
+python scripts\kb_org_install_github_automation.py --org-root <local-org-mirror>
+python scripts\kb_org_configure_github_repo.py --repo-url <github-org-kb-url> --use-git-credential
+```
+
+Remote GitHub creation and initial push are complete for the private sandbox.
+Pull request opening is still a later integration step: the current local tools
+can prepare an import branch, and the GitHub connector can open a PR after a
+branch is pushed, but the contribution PR flow has not yet been wired into the
+desktop organization workflow.
+
 ## First MVP
 
 The first useful organization MVP should include only:
 
+- private GitHub sandbox repository seeded with real shareable cards;
 - organization GitHub repo configuration;
 - local read-only mirror sync;
 - source/provenance metadata;
@@ -618,11 +1552,16 @@ include:
 - sleep-generated organization candidate outbox;
 - reusable-model filtering that excludes preferences by default;
 - duplicate/update detection against organization cards;
+- local organization-card adoption and fork evidence;
 - card-led Skill dependency detection;
-- branch or pull request preparation to candidate/import paths.
+- branch or pull request preparation to candidate/import paths;
+- GitHub Actions checks and auto-merge rules for eligible low-risk maintenance
+  pull requests.
 
-Skill installation, maintainer write tools, and direct trusted-card maintenance
-should come after the automatic candidate path is reliable.
+Organization-review Skill installation, policy-approved approved-Skill
+auto-installation, and organization maintenance proposals should come after the
+automatic candidate path is reliable. Direct trusted-card maintenance should
+still go through reviewed GitHub branches or pull requests.
 
 ## Non-Goals For The First Organization Pass
 
@@ -631,6 +1570,6 @@ should come after the automatic candidate path is reliable.
 - No vector database.
 - No direct multi-user writes to trusted cards.
 - No automatic private-card upload.
-- No automatic Skill installation.
+- No automatic installation of candidate, rejected, unknown, or unpinned Skills.
 - No separate enterprise edition unless later requirements demand SSO,
   centralized policy enforcement, or audit dashboards.

--- a/docs/organization_structure_audit.md
+++ b/docs/organization_structure_audit.md
@@ -1,0 +1,278 @@
+# Organization Mode Structure Audit
+
+This audit records structure and capability gaps found while starting the
+organization-mode functional acceptance pass. It distinguishes small safe fixes
+from larger architecture work that should not be hidden inside test cleanup.
+
+## Current State
+
+Organization mode is now covered by a mixture of module tests and local e2e
+tests. Existing tests cover source validation, multi-source search, adoption,
+outbox generation, contribution branch preparation, organization checks,
+Skill bundle sharing, automation gates, and a two-profile local organization
+flow. The newer two-machine cache-pool lifecycle test covers the intended
+sync model: machines search a synchronized local organization mirror/cache, not
+the remote repository directly.
+
+The main gap is not raw test count. The main gap is that the tests were not yet
+organized as a named functional acceptance suite, and organization maintenance
+cleanup is still mostly a check/report workflow rather than an apply workflow.
+
+## Module Boundary Findings
+
+### `local_kb/org_sources.py`
+
+Current role: validate, clone, fetch, and connect organization repositories.
+
+Assessment: boundary is reasonable. Keep as the source/mirror layer.
+The local mirror is the organization cache pool used by browsing and search.
+Existing mirrors must be updated when the source repository changes; a fetch
+that does not update the worktree is not enough for cache synchronization.
+
+Low-risk cleanup:
+
+- add shared test helpers for valid/invalid organization repos;
+- keep validation messages stable so UI and e2e tests can assert them.
+
+### `local_kb/adoption.py`
+
+Current role: use-on-hash adoption, exchange ledger, local adopted copies, and
+card-bound Skill bundle import on organization card use.
+
+Assessment: functionality is coherent, but the file now owns both card
+adoption and imported Skill side effects.
+
+Possible future split:
+
+- keep card hash/adoption ledger in `adoption.py`;
+- move organization Skill import-on-adoption orchestration into a small
+  `org_skill_adoption.py` or `skill_sharing.py` facade if this grows.
+
+Not blocking current acceptance.
+
+### `local_kb/org_outbox.py`
+
+Current role: filter local cards for organization contribution, dedupe by
+exchange hash, create candidate payloads, and attach card-bound Skill bundles.
+
+Assessment: boundary is acceptable for now, but Skill materialization makes the
+module more than card-only export.
+
+Future cleanup:
+
+- extract outbox fixture/helper code in tests;
+- keep Skill bundle materialization in `skill_sharing.py`, called by outbox.
+
+### `local_kb/org_contribution.py`
+
+Current role: copy generated outbox files into organization repo imports,
+create branches, commit, and optionally push.
+
+Assessment: boundary is clear. It now correctly copies nested Skill bundle
+files, not only top-level YAML proposals.
+
+Low-risk cleanup:
+
+- add e2e assertion that nested bundle files survive contribution branch copy.
+
+### `local_kb/org_checks.py`
+
+Current role: validate organization repo safety, path policy, privacy, Skill
+registry pinning, card duplicate hashes, and low-risk auto-merge eligibility.
+
+Assessment: strong check/report layer. It should remain non-mutating.
+
+Important boundary:
+
+- duplicate hash detection is a blocker/report, not cleanup;
+- duplicate Skill `id` is now a warning handle collision, not an identity
+  failure;
+- Skill identity belongs to `bundle_id + content_hash + version_time`.
+
+### `local_kb/org_maintenance.py`
+
+Current role: build a maintenance report from validation, checks, outbox count,
+candidate count, skill registry count, review-skill availability, and cleanup
+signals.
+
+Assessment: currently a report/intake layer plus cleanup proposal summary. It
+does not itself merge cards, delete cards, reject weak cards, or promote
+candidates; those actions live in `org_cleanup.py`.
+
+New explicit signals:
+
+- duplicate content hash count;
+- organization check summary;
+- cleanup proposal action count and counts by action type;
+- planned cleanup capabilities:
+  - similar-card merge apply: planned;
+  - weak-card rejection apply: available through `org_cleanup.py`;
+  - candidate delete apply: available only when explicitly allowed;
+  - Skill bundle cleanup apply: partial.
+
+Large follow-up:
+
+- continue expanding `org_cleanup.py` instead of overloading this report
+  function.
+
+### `local_kb/skill_sharing.py`
+
+Current role: dependency extraction, local Skill lookup, card-bound bundle
+metadata, outbox Skill bundle materialization, imported Skill bundle storage,
+bundle consolidation, registry loading, auto-install eligibility, source
+checkout, install, and UI dependency annotation.
+
+Assessment: this file is now broad. It is the clearest future split candidate.
+
+Possible target modules:
+
+- `skill_dependencies.py`: dependency extraction and annotation payload shape.
+- `skill_bundles.py`: `bundle_id`, version selection, imported bundle storage,
+  bundle consolidation.
+- `skill_registry.py`: organization registry load, validation normalization,
+  by-id/by-bundle indexes.
+- `skill_install.py`: approved Skill checkout/hash/install policy.
+
+Do not split yet unless acceptance tests are stable, because this module is
+central to card-bound Skill behavior.
+
+### `local_kb/desktop_app.py`
+
+Current role: complete Tk desktop UI, settings, organization panel, card board,
+card detail, source filters, and display helpers.
+
+Assessment: file is large, but recent UI changes are localized and covered by
+tests. Splitting now would be higher risk than value unless a UI regression
+requires it.
+
+Possible future split:
+
+- `desktop_text.py`: UI text and display label helpers;
+- `desktop_cards.py`: card rendering helpers;
+- `desktop_settings.py`: settings dialog;
+- `desktop_organization.py`: organization status panel.
+
+Not blocking current functional acceptance.
+
+## Organization Maintenance Cleanup Gap
+
+The user specifically asked whether organization maintenance can merge,
+delete, downgrade, or reject organization cards.
+
+Current true state:
+
+- exact duplicate content hashes are detected and block low-risk auto-merge;
+- maintenance reports now surface duplicate-hash cleanup signals;
+- `org_cleanup.py` now produces deterministic cleanup proposals for duplicate
+  cards, weak cards, trusted low-confidence cards, high-confidence promotion
+  review, similar-title merge review, stale delete review, and card-bound Skill
+  version selection;
+- cleanup apply supports audited confidence/status changes, duplicate marking,
+  and deletion when explicitly allowed;
+- similar-card merge, overloaded-card split, trusted rewrite, and candidate
+  promotion remain proposal/review only;
+- local semantic review can apply some actions to a local KB, such as rewrite,
+  promote, demote, deprecate, and confidence adjustment;
+- semantic review merge/split decisions are currently proposal-only;
+- imported organization Skill bundle cleanup is implemented locally and keeps
+  the latest version per `bundle_id`;
+- organization registry-level Skill cleanup is still check/index oriented.
+
+Recommended future shape:
+
+1. Continue using `local_kb/org_cleanup.py` as the organization cleanup
+   planning and apply module.
+2. It produces a deterministic proposal object before mutation. Trusted
+   files and deletions are allowed later, but only through proposal, audit, and
+   Git-check guarded apply.
+3. Proposal types should include:
+   - duplicate-hash rejection or consolidation;
+   - similar-card merge proposal;
+   - weak-card reject/deprecate proposal;
+   - overloaded-card split proposal;
+   - supersede/deprecate proposal;
+   - confidence adjustment proposal;
+   - trusted-card rewrite, score, merge, split, or delete proposal;
+   - Skill bundle latest-version and approval-state proposal.
+4. Add a separate apply path in phases:
+   - first, low-risk candidate/import confidence and status adjustments;
+   - then trusted confidence/status/rewrite/merge/split when checks and audit
+     are stable;
+   - finally deletion with tombstone or audit records.
+5. GitHub checks should continue to guard final merge.
+
+## Test Structure Findings
+
+Current coverage is broad but unevenly named. Recommended additions:
+
+- `tests/test_e2e_organization_connection.py`
+- `tests/test_e2e_multi_source_browsing.py`
+- `tests/test_e2e_organization_adoption.py`
+- `tests/test_e2e_skill_bundle_lifecycle.py`
+- `tests/test_e2e_org_contribution_flow.py`
+- `tests/test_e2e_organization_maintenance_cleanup.py`
+- `tests/test_e2e_org_cli_flow.py`
+
+Already added in this pass:
+
+- `tests/test_e2e_organization_connection.py`
+- `tests/test_e2e_multi_source_browsing.py`
+- `tests/test_e2e_organization_maintenance_cleanup.py`
+- `tests/test_e2e_skill_bundle_contribution_flow.py`
+- `tests/test_e2e_two_machine_cache_pool_lifecycle.py`
+- `tests/test_org_cleanup.py`
+
+Recommended helper extraction:
+
+- `tests/org_helpers.py` now contains the shared valid org repo fixture, card
+  fixture, git helper, local Skill fixture, organization connection helper, and
+  organization outbox-to-candidate publisher.
+- it includes a stable four-card organization sandbox fixture:
+  - two cards designed to overlap with local cards for hash/similarity tests;
+  - two organization-only cards for cache, adoption, and Skill lifecycle tests.
+
+Future helper cleanup:
+
+- migrate older e2e tests onto `tests/org_helpers.py` gradually;
+- add a JSON script runner helper when CLI e2e coverage is added.
+
+Do not extract helpers prematurely before the first few e2e tests settle.
+
+## Immediate Low-Risk Cleanup Done
+
+- Added functional acceptance plan documentation.
+- Added e2e tests for validated organization connection and personal-mode
+  fallback.
+- Added e2e tests for settings-sourced multi-source browsing, same-hash hiding,
+  and different-hash organization resurfacing.
+- Added e2e tests for outbox -> organization import branch contribution with
+  nested card-bound Skill bundle files preserved and low-risk checks passing.
+- Added e2e tests for two-machine organization cache-pool sync, adoption,
+  Skill import, and diverged feedback export.
+- Added `tests/org_helpers.py` with the four-card sandbox fixture.
+- Added `local_kb/org_cleanup.py` proposal/apply first version with confidence
+  adjustment, status adjustment, duplicate marking, guarded deletion, merge
+  review, and Skill version-selection proposals.
+- Shortened card-bound Skill bundle organization paths to avoid Windows mirror
+  sync failures from long filenames.
+- Updated existing organization mirrors to `fetch` and then `pull --ff-only`
+  so the local cache worktree actually updates.
+- Added organization maintenance cleanup signals to the maintenance report.
+- Added e2e tests for duplicate hash report-only behavior and imported Skill
+  bundle latest-version cleanup.
+- Kept organization card cleanup apply as planned rather than pretending it is
+  implemented.
+
+## Next Recommended Steps
+
+1. Add CLI e2e coverage for organization configure/check/contribute/maintain
+   scripts.
+2. Expand `org_cleanup.py` with merge/split proposal payloads that include the
+   proposed merged or split card bodies, not only action markers.
+3. Add trusted rewrite apply behind explicit `allow_trusted` and GitHub check
+   gates.
+4. Add tombstone handling for deletion if hard delete needs a local audit file
+   beyond Git history.
+5. Migrate older tests to `tests/org_helpers.py` where it reduces duplication.
+6. Only after the e2e suite is stable, consider splitting `skill_sharing.py` and
+   `desktop_app.py`.

--- a/local_kb/adoption.py
+++ b/local_kb/adoption.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+import copy
+from datetime import date, datetime
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from local_kb.card_ids import new_card_id
+from local_kb.models import Entry
+from local_kb.org_sources import utc_timestamp
+from local_kb.skill_sharing import (
+    consolidate_imported_skill_bundles,
+    extract_card_bound_skill_bundle_dependencies,
+    install_imported_skill_bundle_version,
+    resolve_skill_bundle_source_dir,
+)
+from local_kb.store import load_entries, load_organization_entries, load_yaml_file, write_yaml_file
+
+
+ADOPTION_KEY = "organization_adoption"
+EXCHANGE_LEDGER_RELATIVE_PATH = Path(".local") / "organization_exchange_hashes.json"
+EXCHANGE_HASH_IGNORED_KEYS = {
+    ADOPTION_KEY,
+    "organization_proposal",
+    "id",
+    "scope",
+    "status",
+    "confidence",
+    "source",
+    "updated_at",
+    "created_at",
+    "i18n",
+}
+EXCHANGE_HASH_ORDER_INSENSITIVE_KEYS = {
+    "cross_index",
+    "related_cards",
+    "required_skills",
+    "tags",
+    "trigger_keywords",
+}
+
+
+def _safe_segment(value: Any) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", text).strip("-")
+    return text or "card"
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _exchange_hash_payload(value: Any, *, key: str = "", top_level: bool = True) -> Any:
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for item_key, item_value in value.items():
+            text_key = str(item_key)
+            if top_level and text_key in EXCHANGE_HASH_IGNORED_KEYS:
+                continue
+            normalized[text_key] = _exchange_hash_payload(item_value, key=text_key, top_level=False)
+        return normalized
+    if isinstance(value, list):
+        items = [_exchange_hash_payload(item, key=key, top_level=False) for item in value]
+        if key in EXCHANGE_HASH_ORDER_INSENSITIVE_KEYS:
+            return sorted(items, key=lambda item: json.dumps(_json_safe(item), ensure_ascii=False, sort_keys=True))
+        return items
+    if isinstance(value, tuple):
+        return [_exchange_hash_payload(item, key=key, top_level=False) for item in value]
+    return _json_safe(value)
+
+
+def card_exchange_hash(data: dict[str, Any]) -> str:
+    payload = _exchange_hash_payload(copy.deepcopy(data))
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def exchange_ledger_path(repo_root: Path) -> Path:
+    return Path(repo_root) / EXCHANGE_LEDGER_RELATIVE_PATH
+
+
+def load_exchange_ledger(repo_root: Path) -> dict[str, Any]:
+    path = exchange_ledger_path(repo_root)
+    if not path.exists():
+        return {"hashes": {}}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"hashes": {}}
+    if not isinstance(payload, dict):
+        return {"hashes": {}}
+    hashes = payload.get("hashes")
+    if not isinstance(hashes, dict):
+        payload["hashes"] = {}
+    return payload
+
+
+def write_exchange_ledger(repo_root: Path, payload: dict[str, Any]) -> Path:
+    path = exchange_ledger_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def record_exchange_hash(
+    repo_root: Path,
+    content_hash: str,
+    *,
+    direction: str,
+    organization_id: str = "",
+    source_repo: str = "",
+    source_path: str = "",
+    local_path: str = "",
+    entry_id: str = "",
+) -> None:
+    content_hash = str(content_hash or "").strip()
+    if not content_hash:
+        return
+    ledger = load_exchange_ledger(repo_root)
+    hashes = ledger.setdefault("hashes", {})
+    if not isinstance(hashes, dict):
+        hashes = {}
+        ledger["hashes"] = hashes
+    now = utc_timestamp()
+    item = hashes.get(content_hash)
+    if not isinstance(item, dict):
+        item = {"first_seen_at": now, "events": []}
+    item["last_seen_at"] = now
+    events = item.setdefault("events", [])
+    if not isinstance(events, list):
+        events = []
+        item["events"] = events
+    events.append(
+        {
+            "direction": str(direction or "").strip(),
+            "organization_id": str(organization_id or "").strip(),
+            "source_repo": str(source_repo or "").strip(),
+            "source_path": str(source_path or "").strip(),
+            "local_path": str(local_path or "").strip(),
+            "entry_id": str(entry_id or "").strip(),
+            "created_at": now,
+        }
+    )
+    hashes[content_hash] = item
+    write_exchange_ledger(repo_root, ledger)
+
+
+def recorded_exchange_hashes(repo_root: Path, directions: set[str] | None = None) -> set[str]:
+    ledger = load_exchange_ledger(repo_root)
+    hashes = ledger.get("hashes") if isinstance(ledger.get("hashes"), dict) else {}
+    if not directions:
+        return {str(content_hash) for content_hash in hashes}
+    selected: set[str] = set()
+    for content_hash, item in hashes.items():
+        events = item.get("events") if isinstance(item, dict) else []
+        if not isinstance(events, list):
+            continue
+        if any(str(event.get("direction") or "") in directions for event in events if isinstance(event, dict)):
+            selected.add(str(content_hash))
+    return selected
+
+
+def adoption_content_hash(data: dict[str, Any]) -> str:
+    payload = copy.deepcopy(data)
+    payload.pop(ADOPTION_KEY, None)
+    payload.pop("id", None)
+    payload = _json_safe(payload)
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def adoption_state(data: dict[str, Any]) -> str:
+    metadata = data.get(ADOPTION_KEY) if isinstance(data.get(ADOPTION_KEY), dict) else {}
+    explicit = str(metadata.get("state") or "").strip()
+    if explicit in {"feedback_ready", "locally_rejected"}:
+        return explicit
+    source_hash = str(metadata.get("source_content_hash") or "").strip()
+    if source_hash and source_hash == adoption_content_hash(data):
+        return "clean"
+    return "diverged"
+
+
+def adoption_key_from_data(data: dict[str, Any]) -> tuple[str, str, str]:
+    metadata = data.get(ADOPTION_KEY) if isinstance(data.get(ADOPTION_KEY), dict) else {}
+    return (
+        str(metadata.get("organization_id") or "").strip(),
+        str(metadata.get("source_entry_id") or "").strip(),
+        str(metadata.get("source_repo") or "").strip(),
+    )
+
+
+def organization_key_from_entry(entry: Entry) -> tuple[str, str, str]:
+    source = entry.source
+    return (
+        str(source.get("organization_id") or source.get("source_id") or "").strip(),
+        str(entry.data.get("id") or "").strip(),
+        str(source.get("source_repo") or "").strip(),
+    )
+
+
+def adopted_organization_keys(repo_root: Path) -> set[tuple[str, str, str]]:
+    keys: set[tuple[str, str, str]] = set()
+    for entry in load_entries(repo_root):
+        key = adoption_key_from_data(entry.data)
+        if key[0] and key[1]:
+            keys.add(key)
+            keys.add((key[0], key[1], ""))
+    return keys
+
+
+def local_exchange_hashes(repo_root: Path) -> set[str]:
+    hashes: set[str] = set()
+    for entry in load_entries(repo_root):
+        hashes.add(card_exchange_hash(entry.data))
+    return hashes
+
+
+def blocked_organization_download_hashes(repo_root: Path) -> set[str]:
+    return local_exchange_hashes(repo_root) | recorded_exchange_hashes(
+        repo_root,
+        {"downloaded", "used", "absorbed", "exported", "uploaded"},
+    )
+
+
+def _local_preference_rank(entry: Entry) -> tuple[int, int, int, str]:
+    data = entry.data
+    has_adoption = isinstance(data.get(ADOPTION_KEY), dict)
+    source_scope = str(entry.source.get("scope") or "").strip().lower()
+    status = str(data.get("status") or "").strip().lower()
+    scope_rank = {"public": 0, "private": 1, "candidate": 2}.get(source_scope, 3)
+    status_rank = {"trusted": 0, "approved": 0, "candidate": 1, "deprecated": 3}.get(status, 2)
+    return (1 if has_adoption else 0, scope_rank, status_rank, str(entry.path))
+
+
+def dedupe_local_entries_by_exchange_hash(entries: list[Entry]) -> list[Entry]:
+    by_hash: dict[str, Entry] = {}
+    for entry in entries:
+        content_hash = card_exchange_hash(entry.data)
+        existing = by_hash.get(content_hash)
+        if existing is None or _local_preference_rank(entry) < _local_preference_rank(existing):
+            by_hash[content_hash] = entry
+    preferred_paths = {entry.path for entry in by_hash.values()}
+    return [entry for entry in entries if entry.path in preferred_paths]
+
+
+def find_local_entry_by_exchange_hash(repo_root: Path, content_hash: str) -> Entry | None:
+    matches = [entry for entry in load_entries(repo_root) if card_exchange_hash(entry.data) == content_hash]
+    if not matches:
+        return None
+    return sorted(matches, key=_local_preference_rank)[0]
+
+
+def adopted_card_path(repo_root: Path, organization_id: str, entry_id: str) -> Path:
+    return repo_root / "kb" / "candidates" / "adopted" / _safe_segment(organization_id) / f"{_safe_segment(entry_id)}.yaml"
+
+
+def find_adopted_entry_by_source(
+    repo_root: Path,
+    *,
+    organization_id: str,
+    source_entry_id: str,
+    source_repo: str = "",
+    source_exchange_hash: str = "",
+) -> Entry | None:
+    matches: list[Entry] = []
+    for entry in load_entries(repo_root):
+        metadata = entry.data.get(ADOPTION_KEY) if isinstance(entry.data.get(ADOPTION_KEY), dict) else {}
+        if str(metadata.get("organization_id") or "").strip() != str(organization_id or "").strip():
+            continue
+        if str(metadata.get("source_entry_id") or "").strip() != str(source_entry_id or "").strip():
+            continue
+        if source_repo and str(metadata.get("source_repo") or "").strip() != str(source_repo or "").strip():
+            continue
+        if source_exchange_hash and str(metadata.get("source_exchange_hash") or "").strip() != source_exchange_hash:
+            continue
+        matches.append(entry)
+    if not matches:
+        return None
+    return sorted(matches, key=_local_preference_rank)[0]
+
+
+def find_organization_entry(
+    entry_id: str,
+    organization_sources: list[dict[str, Any]],
+    source_info: dict[str, Any] | None = None,
+) -> Entry | None:
+    source_info = source_info if isinstance(source_info, dict) else {}
+    for source in organization_sources:
+        org_root = Path(str(source.get("path") or source.get("local_path") or ""))
+        organization_id = str(source.get("organization_id") or source.get("id") or "").strip()
+        if not org_root.exists() or not organization_id:
+            continue
+        entries = load_organization_entries(
+            org_root,
+            organization_id,
+            source_repo=str(source.get("source_repo") or source.get("repo_url") or ""),
+            source_commit=str(source.get("source_commit") or ""),
+        )
+        for entry in entries:
+            if str(entry.data.get("id") or "").strip() != str(entry_id or "").strip():
+                continue
+            if source_info:
+                expected_path = str(source_info.get("path") or "").strip()
+                if expected_path and str(entry.source.get("path") or "").strip() != expected_path:
+                    continue
+                expected_org = str(source_info.get("organization_id") or "").strip()
+                if expected_org and str(entry.source.get("organization_id") or "").strip() != expected_org:
+                    continue
+            return entry
+    return None
+
+
+def adopt_organization_entry(repo_root: Path, entry: Entry) -> dict[str, Any]:
+    if entry.source.get("kind") != "organization":
+        return {"ok": False, "error": "entry is not from an organization source"}
+    entry_id = str(entry.data.get("id") or entry.path.stem).strip()
+    organization_id = str(entry.source.get("organization_id") or entry.source.get("source_id") or "org").strip()
+    now = utc_timestamp()
+    source_hash = adoption_content_hash(entry.data)
+    source_exchange_hash = card_exchange_hash(entry.data)
+    existing_adoption = find_adopted_entry_by_source(
+        repo_root,
+        organization_id=organization_id,
+        source_entry_id=entry_id,
+        source_repo=str(entry.source.get("source_repo") or ""),
+        source_exchange_hash=source_exchange_hash,
+    )
+    if existing_adoption is not None:
+        target_path = existing_adoption.path
+        installed_skill_bundles = adopt_entry_skill_bundles(
+            repo_root,
+            entry,
+            source_card_id=str(existing_adoption.data.get("id") or target_path.stem),
+        )
+        existing = copy.deepcopy(existing_adoption.data)
+        metadata = existing.get(ADOPTION_KEY) if isinstance(existing.get(ADOPTION_KEY), dict) else {}
+        hit_count = int(metadata.get("hit_count") or 0) if str(metadata.get("hit_count") or "").isdigit() else 0
+        metadata.update(
+            {
+                "last_used_at": now,
+                "hit_count": hit_count + 1,
+                "source_exchange_hash": metadata.get("source_exchange_hash") or source_exchange_hash,
+            }
+        )
+        existing[ADOPTION_KEY] = metadata
+        write_yaml_file(target_path, existing)
+        record_exchange_hash(
+            repo_root,
+            source_exchange_hash,
+            direction="used",
+            organization_id=organization_id,
+            source_repo=str(entry.source.get("source_repo") or ""),
+            source_path=str(entry.source.get("path") or ""),
+            local_path=str(target_path),
+            entry_id=str(existing.get("id") or target_path.stem),
+        )
+        return {
+            "ok": True,
+            "created": False,
+            "path": str(target_path),
+            "entry_id": str(existing.get("id") or entry_id),
+            "state": adoption_state(existing),
+            "hit_count": metadata["hit_count"],
+            "installed_skill_bundles": installed_skill_bundles,
+        }
+
+    existing_local = find_local_entry_by_exchange_hash(repo_root, source_exchange_hash)
+    if existing_local is not None:
+        installed_skill_bundles = adopt_entry_skill_bundles(
+            repo_root,
+            entry,
+            source_card_id=str(existing_local.data.get("id") or existing_local.path.stem),
+        )
+        record_exchange_hash(
+            repo_root,
+            source_exchange_hash,
+            direction="absorbed",
+            organization_id=organization_id,
+            source_repo=str(entry.source.get("source_repo") or ""),
+            source_path=str(entry.source.get("path") or ""),
+            local_path=str(existing_local.path),
+            entry_id=str(existing_local.data.get("id") or existing_local.path.stem),
+        )
+        return {
+            "ok": True,
+            "created": False,
+            "matched_existing": True,
+            "path": str(existing_local.path),
+            "entry_id": str(existing_local.data.get("id") or existing_local.path.stem),
+            "state": "already_local",
+            "hit_count": 1,
+            "source_exchange_hash": source_exchange_hash,
+            "installed_skill_bundles": installed_skill_bundles,
+        }
+
+    payload = copy.deepcopy(entry.data)
+    payload["id"] = new_card_id(repo_root, prefix="cand", generated_at=now)
+    payload[ADOPTION_KEY] = {
+        "organization_id": organization_id,
+        "source_entry_id": entry_id,
+        "source_repo": str(entry.source.get("source_repo") or ""),
+        "source_commit": str(entry.source.get("source_commit") or ""),
+        "source_path": str(entry.source.get("path") or ""),
+        "adopted_at": now,
+        "last_used_at": now,
+        "hit_count": 1,
+        "source_content_hash": source_hash,
+        "source_exchange_hash": source_exchange_hash,
+        "state": "clean",
+    }
+    target_path = adopted_card_path(repo_root, organization_id, str(payload["id"]))
+    write_yaml_file(target_path, payload)
+    installed_skill_bundles = adopt_entry_skill_bundles(repo_root, entry, source_card_id=str(payload["id"]))
+    record_exchange_hash(
+        repo_root,
+        source_exchange_hash,
+        direction="downloaded",
+        organization_id=organization_id,
+        source_repo=str(entry.source.get("source_repo") or ""),
+        source_path=str(entry.source.get("path") or ""),
+        local_path=str(target_path),
+        entry_id=str(payload["id"]),
+    )
+    return {
+        "ok": True,
+        "created": True,
+        "path": str(target_path),
+        "entry_id": str(payload["id"]),
+        "state": "clean",
+        "hit_count": 1,
+        "source_exchange_hash": source_exchange_hash,
+        "installed_skill_bundles": installed_skill_bundles,
+    }
+
+
+def adopt_organization_entry_by_source_info(
+    repo_root: Path,
+    entry_id: str,
+    organization_sources: list[dict[str, Any]],
+    source_info: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    entry = find_organization_entry(entry_id, organization_sources, source_info=source_info)
+    if entry is None:
+        return {"ok": False, "error": "organization entry not found"}
+    return adopt_organization_entry(repo_root, entry)
+
+
+def _organization_root_for_entry(entry: Entry) -> Path:
+    relative = Path(str(entry.source.get("path") or ""))
+    if relative.parts:
+        try:
+            return entry.path.parents[len(relative.parts) - 1]
+        except IndexError:
+            pass
+    return entry.path.parents[2] if len(entry.path.parents) > 2 else entry.path.parent
+
+
+def adopt_entry_skill_bundles(repo_root: Path, entry: Entry, *, source_card_id: str = "") -> dict[str, Any]:
+    if entry.source.get("kind") != "organization":
+        return {"ok": True, "installed": [], "errors": [], "consolidation": {"ok": True, "bundle_count": 0}}
+
+    installed: list[dict[str, Any]] = []
+    errors: list[str] = []
+    org_root = _organization_root_for_entry(entry)
+    for dependency in extract_card_bound_skill_bundle_dependencies(entry.data):
+        source_dir = resolve_skill_bundle_source_dir(org_root, entry.source, dependency)
+        if source_dir is None:
+            errors.append(f"missing Skill bundle source for {dependency.get('bundle_id') or dependency.get('id')}")
+            continue
+        result = install_imported_skill_bundle_version(
+            repo_root,
+            dependency,
+            source_dir,
+            source_card_id=source_card_id or str(entry.data.get("id") or entry.path.stem),
+            status="approved" if str(entry.data.get("status") or "").strip() in {"trusted", "approved"} else "candidate",
+        )
+        if result.get("ok"):
+            installed.append(result)
+        else:
+            errors.extend(str(error) for error in result.get("errors") or [])
+
+    consolidation = consolidate_imported_skill_bundles(repo_root)
+    return {
+        "ok": not errors and bool(consolidation.get("ok")),
+        "installed": installed,
+        "errors": errors,
+        "consolidation": consolidation,
+    }

--- a/local_kb/card_ids.py
+++ b/local_kb/card_ids.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+INSTALLATION_ID_RELATIVE_PATH = Path(".local") / "khaos_brain_installation.json"
+
+
+def _safe_id_component(value: Any, *, fallback: str) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9_.-]+", "-", text).strip("-")
+    return text or fallback
+
+
+def _parse_time(value: Any) -> datetime:
+    text = str(value or "").strip()
+    if text:
+        normalized = text.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc)
+
+
+def compact_utc_timestamp(value: Any = None) -> str:
+    return _parse_time(value).strftime("%Y%m%dT%H%M%SZ")
+
+
+def installation_identity_path(repo_root: Path) -> Path:
+    return Path(repo_root) / INSTALLATION_ID_RELATIVE_PATH
+
+
+def load_or_create_installation_id(repo_root: Path) -> str:
+    path = installation_identity_path(repo_root)
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            payload = {}
+        if isinstance(payload, dict):
+            installation_id = str(payload.get("local_installation_id") or "").strip()
+            if installation_id:
+                return installation_id
+
+    installation_id = str(uuid4())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "local_installation_id": installation_id,
+                "created_at": compact_utc_timestamp(),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return installation_id
+
+
+def installation_short_label(repo_root: Path) -> str:
+    compact = re.sub(r"[^a-fA-F0-9]+", "", load_or_create_installation_id(repo_root)).lower()
+    return f"inst{(compact or 'local')[:8]}"
+
+
+def new_card_id(
+    repo_root: Path,
+    *,
+    prefix: str = "card",
+    generated_at: Any = None,
+    author_hint: str = "",
+    random_code: str | None = None,
+) -> str:
+    safe_prefix = _safe_id_component(prefix, fallback="card")
+    author_or_install = _safe_id_component(author_hint, fallback="")
+    if not author_or_install:
+        author_or_install = installation_short_label(repo_root)
+    random_part = _safe_id_component(random_code or secrets.token_hex(3), fallback=secrets.token_hex(3))
+    return f"{safe_prefix}-{compact_utc_timestamp(generated_at)}-{author_or_install}-{random_part}"

--- a/local_kb/consolidate_apply.py
+++ b/local_kb/consolidate_apply.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+from local_kb.adoption import card_exchange_hash, find_local_entry_by_exchange_hash
+from local_kb.card_ids import new_card_id
 from local_kb.common import normalize_string_list, parse_route_segments, slugify
 from local_kb.consolidate_events import (
     APPLY_MODE_CROSS_INDEX,
@@ -229,12 +231,6 @@ def emit_artifacts(
     return artifact_paths
 
 
-def route_candidate_id(route_ref: str) -> str:
-    route_slug = slugify(route_ref.replace("/", "-"))[:32] or "route"
-    route_hash = hashlib.sha1(route_ref.encode("utf-8")).hexdigest()[:8]
-    return f"cand-auto-{route_slug}-{route_hash}"
-
-
 def summarize_examples(values: list[str], limit: int = 3) -> str:
     if not values:
         return ""
@@ -244,6 +240,7 @@ def summarize_examples(values: list[str], limit: int = 3) -> str:
 
 
 def build_auto_candidate_entry(
+    repo_root: Path,
     action: dict[str, Any],
     supporting_events: list[dict[str, Any]],
     run_id: str,
@@ -285,7 +282,7 @@ def build_auto_candidate_entry(
     if alternatives:
         tags = sorted(set(tags + ["contrastive-evidence"]))
     return {
-        "id": route_candidate_id(route_ref),
+        "id": new_card_id(repo_root, prefix="cand", generated_at=generated_at),
         "title": str(scaffold_preview.get("title", "") or f"Repeated route gap in {route_title}"),
         "type": "model",
         "scope": AUTO_CANDIDATE_SCOPE,
@@ -435,11 +432,24 @@ def apply_new_candidate_actions(
             continue
 
         entry = build_auto_candidate_entry(
+            repo_root,
             action=action,
             supporting_events=supporting_events,
             run_id=run_id,
             generated_at=generated_at,
         )
+        existing_same_hash = find_local_entry_by_exchange_hash(repo_root, card_exchange_hash(entry))
+        if existing_same_hash is not None:
+            skipped_actions.append(
+                {
+                    "action_key": action["action_key"],
+                    "action_type": action["action_type"],
+                    "target": dict(action["target"]),
+                    "reason": f"Candidate content hash already exists: {relative_repo_path(repo_root, existing_same_hash.path)}",
+                    "event_ids": list(action["event_ids"]),
+                }
+            )
+            continue
         target_path = candidate_dir(repo_root) / f"{entry['id']}.yaml"
         relative_target_path = relative_repo_path(repo_root, target_path)
         if target_path.exists():

--- a/local_kb/desktop_app.py
+++ b/local_kb/desktop_app.py
@@ -27,6 +27,7 @@ from tkinter import ttk
 
 from PIL import Image, ImageDraw, ImageFilter, ImageTk
 
+from local_kb.adoption import adopt_organization_entry_by_source_info
 from local_kb.common import normalize_text
 from local_kb.i18n import (
     DEFAULT_LANGUAGE,
@@ -36,12 +37,23 @@ from local_kb.i18n import (
     localized_route_title,
     normalize_language,
 )
-from local_kb.settings import load_desktop_settings, save_desktop_settings
+from local_kb.org_maintenance import build_organization_maintenance_report
+from local_kb.org_sources import connect_organization_source
+from local_kb.settings import (
+    ORGANIZATION_MODE,
+    PERSONAL_MODE,
+    load_desktop_settings,
+    maintenance_participation_status_from_settings,
+    organization_sources_from_settings,
+    save_desktop_settings,
+)
 from local_kb.store import resolve_repo_root
 from local_kb.ui_data import (
     build_card_detail_payload,
     build_route_view_payload,
     build_search_payload,
+    build_skill_registry_payload,
+    build_source_view_payload,
     navigation_card_count,
     navigation_children,
 )
@@ -62,6 +74,7 @@ MIN_WINDOW_SIZE = (1080, 720)
 SIDEBAR_WIDTH = 344
 MAIN_MARGIN_X = 36
 MAIN_MAX_COLUMNS = 5
+MAIN_WHEEL_SCROLL_UNITS = 3
 
 
 def _runtime_asset_root() -> Path:
@@ -75,11 +88,33 @@ ASSET_DIR = _runtime_asset_root() / "assets"
 APP_ICON_PATH = ASSET_DIR / "khaos-brain-icon.png"
 BRAND_ICON_PATH = ASSET_DIR / "khaos-brain-icon-sidebar.png"
 PROJECT_GITHUB_URL = "https://github.com/liuyingxuvka/Khaos-Brain"
-SUPPORT_PAYPAL = "liu.yingxu.vka@gmail.com"
+VOLUNTARY_SUPPORT_URL = "https://paypal.me/Yingxuliu"
 
 LANGUAGE_DISPLAY_OPTIONS = {
     DEFAULT_LANGUAGE: "English / 英文",
     ZH_CN: "中文 / Chinese",
+}
+
+MODE_DISPLAY_OPTIONS = {
+    DEFAULT_LANGUAGE: {
+        PERSONAL_MODE: "Personal",
+        ORGANIZATION_MODE: "Organization",
+    },
+    ZH_CN: {
+        PERSONAL_MODE: "个人",
+        ORGANIZATION_MODE: "组织",
+    },
+}
+
+MAINTENANCE_DISPLAY_OPTIONS = {
+    DEFAULT_LANGUAGE: {
+        "off": "Do not participate",
+        "on": "Participate",
+    },
+    ZH_CN: {
+        "off": "不参与组织维护",
+        "on": "参与组织维护",
+    },
 }
 
 
@@ -93,16 +128,68 @@ def _language_from_display(value: str) -> str:
             return language
     return normalize_language(value)
 
+
+def _wheel_scroll_units(delta: float, *, multiplier: int = 1) -> int:
+    units = int(-1 * (delta / 120) * multiplier)
+    if units == 0 and delta:
+        return -1 if delta > 0 else 1
+    return units
+
+
+def _mode_display(mode: str, language: str = DEFAULT_LANGUAGE) -> str:
+    normalized_language = normalize_language(language)
+    mode = mode if mode in {PERSONAL_MODE, ORGANIZATION_MODE} else PERSONAL_MODE
+    return MODE_DISPLAY_OPTIONS.get(normalized_language, MODE_DISPLAY_OPTIONS[DEFAULT_LANGUAGE])[mode]
+
+
+def _mode_from_display(value: str, language: str = DEFAULT_LANGUAGE) -> str:
+    normalized_language = normalize_language(language)
+    for mode, label in MODE_DISPLAY_OPTIONS.get(normalized_language, MODE_DISPLAY_OPTIONS[DEFAULT_LANGUAGE]).items():
+        if value == label:
+            return mode
+    for options in MODE_DISPLAY_OPTIONS.values():
+        for mode, label in options.items():
+            if value == label:
+                return mode
+    return PERSONAL_MODE
+
+
+def _maintenance_display(enabled: bool, language: str = DEFAULT_LANGUAGE) -> str:
+    normalized_language = normalize_language(language)
+    key = "on" if enabled else "off"
+    return MAINTENANCE_DISPLAY_OPTIONS.get(normalized_language, MAINTENANCE_DISPLAY_OPTIONS[DEFAULT_LANGUAGE])[key]
+
+
+def _maintenance_from_display(value: str, language: str = DEFAULT_LANGUAGE) -> bool:
+    normalized_language = normalize_language(language)
+    options = MAINTENANCE_DISPLAY_OPTIONS.get(normalized_language, MAINTENANCE_DISPLAY_OPTIONS[DEFAULT_LANGUAGE])
+    if value == options["on"]:
+        return True
+    if value == options["off"]:
+        return False
+    for translated in MAINTENANCE_DISPLAY_OPTIONS.values():
+        if value == translated["on"]:
+            return True
+        if value == translated["off"]:
+            return False
+    return False
+
 UI_TEXT = {
     DEFAULT_LANGUAGE: {
         "all_cards": "All Cards",
         "predictive_memory_cards": "Predictive memory cards",
         "cards_suffix": "cards",
         "library": "Library",
+        "status": "Status",
+        "type": "Type",
+        "paths": "Paths",
         "trusted": "Trusted",
         "candidates": "Candidates",
+        "deprecated": "Deprecated",
         "models": "Models",
         "preferences": "Preferences",
+        "heuristics": "Heuristics",
+        "facts": "Facts",
         "routes": "Routes",
         "settings": "Settings / 设置",
         "about": "About / 关于",
@@ -116,6 +203,19 @@ UI_TEXT = {
         "display_language": "Language / 语言",
         "language_hint": "Choose the display language. Card source text stays canonical in English.",
         "english_canonical": "English remains the canonical card source. Chinese is a display layer maintained during sleep.",
+        "mode": "Mode",
+        "mode_hint": "Personal is for one local user. Organization connects a shared GitHub KB for a team.",
+        "personal_mode": "Personal",
+        "organization_mode": "Organization",
+        "organization_repo_url": "Organization GitHub repository",
+        "organization_repo_hint": "Organization mode only turns on after this repository clones and validates as a Khaos organization KB.",
+        "organization_not_connected": "No validated organization repository.",
+        "organization_connected": "Connected",
+        "organization_invalid": "Organization repository is not valid.",
+        "organization_validating": "Validating organization repository...",
+        "maintainer_mode": "Participate in organization maintenance",
+        "maintainer_hint": "When enabled, this machine periodically prepares organization repository maintenance proposals.",
+        "validate_and_save": "Validate & Save",
         "settings_title": "Settings / 设置",
         "about_title": "About Khaos Brain",
         "if": "If",
@@ -126,13 +226,34 @@ UI_TEXT = {
         "primary": "Primary",
         "also": "Also",
         "related": "Related",
+        "source": "Source",
+        "source_scope": "Source",
+        "local_source": "Local",
+        "organization_source": "Organization",
+        "author": "Author",
+        "skill_dependencies": "Skill dependencies",
+        "skill_badge": "Skill",
+        "registry_status": "Registry",
+        "auto_install": "Auto install",
+        "eligible": "eligible",
+        "not_eligible": "not eligible",
+        "organization_panel": "Organization",
+        "organization_panel_title": "Organization Status",
+        "organization_loading": "Loading organization information...",
+        "organization_source_count": "Organization sources",
+        "organization_skills": "Organization Skills",
+        "maintenance": "Maintenance",
+        "recommendations": "Recommendations",
+        "read_only": "Read-only",
         "recent_history": "Recent history",
         "search_title": "Search",
         "about_body": (
             "A local predictive memory library for Codex.\n\n"
             "Latest version:\n{github_url}\n\n"
-            "If Khaos Brain helps your work, you can buy the developer a coffee via PayPal:\n"
-            "{paypal}\n\n"
+            "If this project is useful to you, you can support its development:\n"
+            "Buy me a coffee via PayPal: {support_url}\n\n"
+            "Support is voluntary and does not purchase support, warranty, priority service, "
+            "commercial rights, or feature requests.\n\n"
             "Cards are stored as auditable files. Routes can surface the same card through multiple paths."
         ),
     },
@@ -141,11 +262,17 @@ UI_TEXT = {
         "predictive_memory_cards": "预测记忆卡片",
         "cards_suffix": "张卡片",
         "library": "资料库",
+        "status": "状态",
+        "type": "类型",
+        "paths": "路径",
         "trusted": "已信任",
         "candidates": "候选",
+        "deprecated": "已废弃",
         "models": "模型",
         "preferences": "偏好",
-        "routes": "路线",
+        "heuristics": "启发式",
+        "facts": "事实",
+        "routes": "路径",
         "settings": "设置 / Settings",
         "about": "关于 / About",
         "search": "搜索",
@@ -158,25 +285,100 @@ UI_TEXT = {
         "display_language": "语言 / Language",
         "language_hint": "选择界面显示语言。卡片源文本仍以英文为规范源。",
         "english_canonical": "英文仍是卡片的规范源；中文是睡眠维护补齐的显示层。",
+        "mode": "模式",
+        "mode_hint": "个人模式只给本机用户使用；组织模式会连接团队共用的 GitHub KB。",
+        "personal_mode": "个人",
+        "organization_mode": "组织",
+        "organization_repo_url": "组织 GitHub 仓库",
+        "organization_repo_hint": "只有仓库能克隆并通过 Khaos 组织 KB manifest 校验后，组织模式才会开启。",
+        "organization_not_connected": "还没有已验证的组织仓库。",
+        "organization_connected": "已连接",
+        "organization_invalid": "组织仓库未通过校验。",
+        "organization_validating": "正在校验组织仓库...",
+        "maintainer_mode": "参与组织维护",
+        "maintainer_hint": "启用后，本机会定期准备组织仓库维护提案。",
+        "validate_and_save": "校验并保存",
         "settings_title": "设置 / Settings",
         "about_title": "关于 Khaos Brain",
         "if": "适用场景",
         "action": "动作/条件",
         "predict": "预测结果",
         "use": "使用方式",
-        "routes_section": "路线",
+        "routes_section": "路径",
         "primary": "主路径",
         "also": "也可从",
         "related": "相关卡片",
+        "source": "来源",
+        "source_scope": "来源",
+        "local_source": "本地",
+        "organization_source": "组织",
+        "author": "制作人",
+        "skill_dependencies": "Skill 依赖",
+        "skill_badge": "技能",
+        "registry_status": "登记状态",
+        "auto_install": "自动安装",
+        "eligible": "可用",
+        "not_eligible": "不可用",
+        "organization_panel": "组织",
+        "organization_panel_title": "组织状态",
+        "organization_loading": "正在加载组织信息...",
+        "organization_source_count": "组织来源",
+        "organization_skills": "组织 Skill",
+        "maintenance": "维护",
+        "recommendations": "建议",
+        "read_only": "只读",
         "recent_history": "最近历史",
         "search_title": "搜索",
         "about_body": (
             "一个给 Codex 使用的本地预测记忆库。\n\n"
             "最新版本：\n{github_url}\n\n"
-            "如果 Khaos Brain 对你的工作有帮助，可以通过 PayPal 请开发者喝咖啡：\n"
-            "{paypal}\n\n"
+            "如果这个项目对你有帮助，可以自愿支持项目维护：\n"
+            "通过 PayPal 请开发者喝杯咖啡：{support_url}\n\n"
+            "自愿支持不代表购买技术支持、质保、优先服务、商业授权或功能定制。\n\n"
             "卡片以可审查文件保存；不同路线可以找到同一张卡片。"
         ),
+    },
+}
+
+STATUS_FILTER_KEYS = {
+    "trusted": "trusted",
+    "candidate": "candidates",
+    "deprecated": "deprecated",
+}
+TYPE_FILTER_KEYS = {
+    "model": "models",
+    "preference": "preferences",
+    "heuristic": "heuristics",
+    "fact": "facts",
+}
+SOURCE_FILTER_KEYS = {
+    "local": "local_source",
+    "organization": "organization_source",
+}
+SOURCE_SCOPE_LABELS = {
+    DEFAULT_LANGUAGE: {
+        "candidate": "Candidate",
+        "private": "Private",
+        "public": "Public",
+        "trusted": "Trusted",
+        "unknown": "",
+    },
+    ZH_CN: {
+        "candidate": "候选",
+        "private": "私有",
+        "public": "公开",
+        "trusted": "已信任",
+        "unknown": "",
+    },
+}
+SOURCE_KIND_LABELS = {
+    DEFAULT_LANGUAGE: {
+        "local": "Local",
+        "organization": "Organization",
+    },
+    ZH_CN: {
+        "local": "本地",
+        "organization": "组织",
     },
 }
 
@@ -427,11 +629,35 @@ def _card_type_value(card: dict[str, Any]) -> str:
     return str(card.get("type") or "model").replace("_", "-").strip().lower()
 
 
+def _type_filter_label(card_type: str, language: str = DEFAULT_LANGUAGE) -> str:
+    value = card_type.replace("_", "-").strip().lower()
+    key = TYPE_FILTER_KEYS.get(value)
+    if key:
+        return _ui_text(language, key)
+    return value.replace("-", " ").title() if value else _ui_text(language, "models")
+
+
 def _status_label(card: dict[str, Any], language: str = DEFAULT_LANGUAGE) -> str:
     value = str(card.get("status") or "card").strip()
     if normalize_language(language) == ZH_CN:
         return {"trusted": "已信任", "candidate": "候选", "deprecated": "已废弃"}.get(value.lower(), value)
     return value
+
+
+def _status_filter_label(status: str, language: str = DEFAULT_LANGUAGE) -> str:
+    value = status.strip().lower()
+    key = STATUS_FILTER_KEYS.get(value)
+    if key:
+        return _ui_text(language, key)
+    return value.replace("-", " ").title() if value else _ui_text(language, "all_cards")
+
+
+def _source_filter_label(source_kind: str, language: str = DEFAULT_LANGUAGE) -> str:
+    value = source_kind.strip().lower()
+    key = SOURCE_FILTER_KEYS.get(value)
+    if key:
+        return _ui_text(language, key)
+    return value.replace("-", " ").title() if value else _ui_text(language, "source_scope")
 
 
 def _confidence_label(card: dict[str, Any]) -> str:
@@ -444,26 +670,108 @@ def _confidence_label(card: dict[str, Any]) -> str:
         return str(value)
 
 
+def _skill_dependency_count(card: dict[str, Any]) -> int:
+    value = card.get("skill_dependency_count")
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        dependencies = card.get("skill_dependencies")
+        count = len(dependencies) if isinstance(dependencies, list) else 0
+    return max(0, count)
+
+
+def _skill_badge_label(card: dict[str, Any], language: str = DEFAULT_LANGUAGE) -> str:
+    count = _skill_dependency_count(card)
+    if count <= 0:
+        return ""
+    if normalize_language(language) == ZH_CN:
+        return f"{count} 个技能"
+    return f"{count} Skill" if count == 1 else f"{count} Skills"
+
+
+def _source_scope_display(scope: str, language: str = DEFAULT_LANGUAGE) -> str:
+    normalized_language = normalize_language(language)
+    value = str(scope or "").strip().lower()
+    labels = SOURCE_SCOPE_LABELS.get(normalized_language, SOURCE_SCOPE_LABELS[DEFAULT_LANGUAGE])
+    return labels.get(value, value.replace("-", " ").title() if value else labels["unknown"])
+
+
+def _source_kind_display(kind: str, language: str = DEFAULT_LANGUAGE) -> str:
+    normalized_language = normalize_language(language)
+    value = str(kind or "").strip().lower()
+    labels = SOURCE_KIND_LABELS.get(normalized_language, SOURCE_KIND_LABELS[DEFAULT_LANGUAGE])
+    return labels.get(value, value.replace("-", " ").title() if value else labels["local"])
+
+
+def _author_display_label(
+    value: Any,
+    language: str = DEFAULT_LANGUAGE,
+    *,
+    source_kind: str = "",
+    organization_id: str = "",
+) -> str:
+    text = str(value or "").strip()
+    normalized_language = normalize_language(language)
+    if not text:
+        return "未注明" if normalized_language == ZH_CN else "Unknown"
+    if text.lower() == "local":
+        return "本机" if normalized_language == ZH_CN else "This device"
+    if source_kind.strip().lower() == "organization" and organization_id and text.lower() == organization_id.lower():
+        return "未注明" if normalized_language == ZH_CN else "Unknown"
+    return text
+
+
+def _author_inline_label(author: str, language: str = DEFAULT_LANGUAGE) -> str:
+    if normalize_language(language) == ZH_CN:
+        return f"作者：{author}"
+    return f"Author: {author}"
+
+
+def _source_line(card: dict[str, Any], language: str = DEFAULT_LANGUAGE) -> str:
+    source_info = card.get("source_info") if isinstance(card.get("source_info"), dict) else {}
+    kind = str(source_info.get("kind") or "").strip().lower()
+    scope = str(source_info.get("scope") or card.get("scope") or "").strip().lower()
+    author = str(card.get("author_label") or "").strip()
+    parts: list[str] = []
+
+    if kind == "local":
+        parts.append(_source_kind_display(kind, language))
+        scope_label = _source_scope_display(scope, language)
+        if scope_label:
+            parts.append(scope_label)
+        author_label = _author_display_label(author, language, source_kind=kind)
+        if author_label:
+            parts.append(_author_inline_label(author_label, language))
+    elif kind == "organization":
+        organization_id = str(source_info.get("organization_id") or source_info.get("source_id") or "").strip()
+        scope_label = _source_scope_display(scope, language)
+        if organization_id:
+            parts.append(f"{_source_kind_display(kind, language)} {organization_id}")
+        else:
+            parts.append(_source_kind_display(kind, language))
+        if scope_label:
+            parts.append(scope_label)
+        author_label = _author_display_label(author, language, source_kind=kind, organization_id=organization_id)
+        if author_label:
+            parts.append(_author_inline_label(author_label, language))
+    else:
+        parts.append(_source_kind_display("local", language))
+        scope_label = _source_scope_display(scope, language)
+        if scope_label:
+            parts.append(scope_label)
+        author_label = _author_display_label(author, language)
+        if author_label:
+            parts.append(_author_inline_label(author_label, language))
+
+    if card.get("read_only"):
+        parts.append("只读" if normalize_language(language) == ZH_CN else "read-only")
+    return " · ".join(parts)
+
+
 def _cover_title(card: dict[str, Any], language: str = DEFAULT_LANGUAGE) -> str:
     raw_title = normalize_text(card.get("title")).strip()
-    if normalize_language(language) == ZH_CN:
-        return raw_title or str(card.get("id") or "卡片")
-
-    title = raw_title.lower()
-    if "local kb" in title and "scanned first" in title:
-        return "Scan KB First"
-    if "release" in title:
-        return "Release Hygiene"
-    if "postflight" in title:
-        return "Postflight Memory"
-    if "route" in title:
-        return "Route Discovery"
-    if "preference" in title or "user" in title:
-        return "User Preference"
-    if "runtime" in title or "codex" in title:
-        return "Runtime Behavior"
-    words = raw_title.split()
-    return " ".join(words[:4]) if words else str(card.get("id") or "Card")
+    fallback = "卡片" if normalize_language(language) == ZH_CN else "Card"
+    return raw_title or str(card.get("id") or fallback)
 
 
 def _text_lines(text: str, max_chars: int, max_lines: int) -> list[str]:
@@ -572,11 +880,13 @@ class KbDesktopApp(tk.Tk):
         selected_language = language if language is not None else self.settings.get("language")
         self.language = normalize_language(selected_language)
         self.settings["language"] = self.language
+        self.organization_sources = organization_sources_from_settings(self.settings)
         self.route = ""
         self.deck: list[dict[str, Any]] = []
         self.selected_index = -1
         self.children_by_route: dict[str, list[dict[str, Any]]] = {}
         self.expanded_routes: set[str] = {""}
+        self.expanded_sidebar_sections: set[str] = set()
         self.nav_hitboxes: list[tuple[int, int, int, int, str, str]] = []
         self.footer_hitboxes: list[tuple[int, int, int, int, str]] = []
         self.card_hitboxes: list[tuple[int, int, int, int, int]] = []
@@ -585,6 +895,9 @@ class KbDesktopApp(tk.Tk):
         self._card_selected_by_user = False
         self.hovered_index = -1
         self._search_after_id: str | None = None
+        self._organization_window: tk.Toplevel | None = None
+        self._organization_window_body: tk.Label | None = None
+        self._organization_window_loading = False
 
         self.title("Khaos Brain")
         self.geometry(f"{self._u(DEFAULT_WINDOW_SIZE[0])}x{self._u(DEFAULT_WINDOW_SIZE[1])}")
@@ -653,6 +966,21 @@ class KbDesktopApp(tk.Tk):
     def _text(self, key: str) -> str:
         return _ui_text(self.language, key)
 
+    def _active_organization_sources(self) -> list[dict[str, Any]]:
+        self.organization_sources = organization_sources_from_settings(self.settings)
+        return self.organization_sources
+
+    def _local_policy_allows_skill_auto_install(self) -> bool:
+        organization = self.settings.get("organization", {}) if isinstance(self.settings.get("organization"), dict) else {}
+        return bool(
+            organization.get("organization_skill_auto_install_allowed")
+            or organization.get("skill_auto_install_allowed")
+        )
+
+    def _should_show_source_metadata(self, card: dict[str, Any] | None = None) -> bool:
+        source_info = (card or {}).get("source_info") if isinstance((card or {}).get("source_info"), dict) else {}
+        return bool(self._active_organization_sources()) or source_info.get("kind") == "organization"
+
     def _build_layout(self) -> None:
         self.grid_columnconfigure(1, weight=1)
         self.grid_rowconfigure(0, weight=1)
@@ -672,7 +1000,7 @@ class KbDesktopApp(tk.Tk):
         self.sidebar.bind("<Button-1>", self._on_sidebar_click)
         self.sidebar.bind("<MouseWheel>", self._on_sidebar_mousewheel)
 
-        self.sidebar_footer = tk.Canvas(self.sidebar_panel, width=self._u(SIDEBAR_WIDTH), height=self._u(104), bg=SIDEBAR, highlightthickness=0)
+        self.sidebar_footer = tk.Canvas(self.sidebar_panel, width=self._u(SIDEBAR_WIDTH), height=self._u(146), bg=SIDEBAR, highlightthickness=0)
         self.sidebar_footer.grid(row=1, column=0, sticky="ew")
         self.sidebar_footer.bind("<Configure>", lambda _event: self._render_footer())
         self.sidebar_footer.bind("<Button-1>", self._on_footer_click)
@@ -1025,6 +1353,21 @@ class KbDesktopApp(tk.Tk):
             for offset in (-5, 0, 5):
                 canvas.create_line(cx - u(8), cy + u(offset - 4), cx + u(8), cy + u(offset + 4), fill=color, width=stroke, tags=tags)
             return
+        if kind == "deprecated":
+            canvas.create_oval(cx - u(8), cy - u(8), cx + u(8), cy + u(8), outline=color, width=stroke, tags=tags)
+            canvas.create_line(cx - u(5), cy + u(5), cx + u(5), cy - u(5), fill=color, width=stroke, tags=tags)
+            return
+        if kind == "status":
+            for offset in (-6, 0, 6):
+                canvas.create_oval(cx - u(9), cy + u(offset) - u(2), cx - u(5), cy + u(offset) + u(2), outline=color, width=stroke, tags=tags)
+                canvas.create_line(cx - u(1), cy + u(offset), cx + u(9), cy + u(offset), fill=color, width=stroke, tags=tags)
+            return
+        if kind == "type":
+            canvas.create_rectangle(cx - u(8), cy - u(8), cx + u(8), cy + u(8), outline=color, width=stroke, tags=tags)
+            canvas.create_line(cx - u(4), cy - u(4), cx + u(4), cy - u(4), fill=color, width=stroke, tags=tags)
+            canvas.create_line(cx, cy - u(4), cx, cy + u(6), fill=color, width=stroke, tags=tags)
+            canvas.create_line(cx - u(4), cy + u(6), cx + u(4), cy + u(6), fill=color, width=stroke, tags=tags)
+            return
         if kind == "model":
             canvas.create_oval(cx - u(9), cy - u(9), cx + u(9), cy + u(9), outline=color, width=stroke, tags=tags)
             canvas.create_oval(cx - u(3), cy - u(3), cx + u(3), cy + u(3), outline=color, width=stroke, tags=tags)
@@ -1043,6 +1386,33 @@ class KbDesktopApp(tk.Tk):
                     width=stroke,
                     tags=tags,
                 )
+            return
+        if kind == "heuristic":
+            canvas.create_oval(cx - u(2), cy - u(2), cx + u(2), cy + u(2), outline=color, width=stroke, tags=tags)
+            for dx, dy in ((-8, -6), (8, -6), (0, 8)):
+                canvas.create_line(cx, cy, cx + u(dx), cy + u(dy), fill=color, width=stroke, tags=tags)
+                canvas.create_oval(cx + u(dx) - u(2), cy + u(dy) - u(2), cx + u(dx) + u(2), cy + u(dy) + u(2), outline=color, width=stroke, tags=tags)
+            return
+        if kind == "fact":
+            canvas.create_oval(cx - u(8), cy - u(8), cx + u(8), cy + u(8), outline=color, width=stroke, tags=tags)
+            canvas.create_line(cx, cy - u(1), cx, cy + u(5), fill=color, width=stroke, tags=tags)
+            canvas.create_oval(cx - u(1), cy - u(6), cx + u(1), cy - u(4), fill=color, outline=color, tags=tags)
+            return
+        if kind == "paths":
+            nodes = ((-8, 5), (0, -5), (8, 4))
+            canvas.create_line(
+                cx + u(nodes[0][0]),
+                cy + u(nodes[0][1]),
+                cx + u(nodes[1][0]),
+                cy + u(nodes[1][1]),
+                cx + u(nodes[2][0]),
+                cy + u(nodes[2][1]),
+                fill=color,
+                width=stroke,
+                tags=tags,
+            )
+            for dx, dy in nodes:
+                canvas.create_oval(cx + u(dx) - u(3), cy + u(dy) - u(3), cx + u(dx) + u(3), cy + u(dy) + u(3), outline=color, width=stroke, tags=tags)
             return
         if kind == "route":
             canvas.create_line(cx - u(7), cy, cx + u(7), cy, fill=color, width=max(stroke, u(1.6)), tags=tags)
@@ -1073,7 +1443,7 @@ class KbDesktopApp(tk.Tk):
         else:
             self._round_rect(self.sidebar, u(24), u(46), u(76), u(98), u(10), fill=ACCENT, tags="chrome")
             self.sidebar.create_text(u(50), u(72), text="KB", fill=BG, font=self._font(17, "bold"), tags="chrome")
-        self.sidebar.create_text(u(96), u(52), text="Khaos Brain", anchor="nw", fill=TEXT, font=self._font(19, "bold"), tags="chrome")
+        self.sidebar.create_text(u(96), u(52), text="Khaos Brain", anchor="nw", fill=TEXT, font=self._font(22, "bold"), tags="chrome")
         self.sidebar.create_text(u(96), u(83), text="Memory Library", anchor="nw", fill=MUTED, font=self._font(12), tags="chrome")
 
         self._round_rect(self.sidebar, u(28), u(128), width - u(36), u(168), u(12), fill=BG, outline=LINE, tags="chrome")
@@ -1083,31 +1453,68 @@ class KbDesktopApp(tk.Tk):
 
         y = u(194)
         self._nav_row(u(28), y, width - u(32), self._text("all_cards"), "cards", "", active=self.route == "" and not self.searching)
-        y += u(44)
-        self._nav_row(u(28), y, width - u(32), self._text("trusted"), "trusted", "", active=self.searching == "trusted")
-        y += u(44)
-        self._nav_row(u(28), y, width - u(32), self._text("candidates"), "candidates", "", active=self.searching == "candidate")
-        y += u(44)
-        self._nav_row(u(28), y, width - u(32), self._text("models"), "type", "model", active=self.searching == "type:model")
-        y += u(44)
-        self._nav_row(
-            u(28),
-            y,
-            width - u(32),
-            self._text("preferences"),
-            "type",
-            "preference",
-            active=self.searching == "type:preference",
-        )
-        y += u(52)
+        y += u(48)
 
-        self.sidebar.create_line(u(34), y - u(18), width - u(40), y - u(18), fill=LINE, tags="chrome")
-        self.sidebar.create_text(u(28), y, text=self._text("routes"), anchor="nw", fill=TEXT, font=self._font(14), tags="chrome")
-        y += u(38)
+        status_active = self.searching.startswith("status:")
+        self._section_row(u(28), y, width - u(32), self._text("status"), "status", active=status_active)
+        y += u(40)
+        if "status" in self.expanded_sidebar_sections:
+            for status in STATUS_FILTER_KEYS:
+                self._nav_row(
+                    u(42),
+                    y,
+                    width - u(36),
+                    _status_filter_label(status, self.language),
+                    "status",
+                    status,
+                    active=self.searching == f"status:{status}",
+                )
+                y += u(38)
+            y += u(8)
 
-        for route, label, depth, active, ancestor, count, declared in self._visible_routes():
-            self._route_row(u(42), y, width - u(40), route, label, depth, active, ancestor, count, declared)
-            y += u(38)
+        type_active = self.searching.startswith("type:")
+        self._section_row(u(28), y, width - u(32), self._text("type"), "type", active=type_active)
+        y += u(40)
+        if "type" in self.expanded_sidebar_sections:
+            for card_type in TYPE_FILTER_KEYS:
+                self._nav_row(
+                    u(42),
+                    y,
+                    width - u(36),
+                    _type_filter_label(card_type, self.language),
+                    "type",
+                    card_type,
+                    active=self.searching == f"type:{card_type}",
+                )
+                y += u(38)
+            y += u(8)
+
+        organization_active = bool(self._active_organization_sources())
+        if organization_active:
+            source_active = self.searching.startswith("source:")
+            self._section_row(u(28), y, width - u(32), self._text("source_scope"), "source", active=source_active)
+            y += u(40)
+            if "source" in self.expanded_sidebar_sections:
+                for source_kind in SOURCE_FILTER_KEYS:
+                    self._nav_row(
+                        u(42),
+                        y,
+                        width - u(36),
+                        _source_filter_label(source_kind, self.language),
+                        "source",
+                        source_kind,
+                        active=self.searching == f"source:{source_kind}",
+                    )
+                    y += u(38)
+                y += u(8)
+
+        path_active = not self.searching and bool(self.route)
+        self._section_row(u(28), y, width - u(32), self._text("paths"), "paths", active=path_active)
+        y += u(40)
+        if "paths" in self.expanded_sidebar_sections:
+            for route, label, depth, active, ancestor, count, declared in self._visible_routes():
+                self._route_row(u(42), y, width - u(40), route, label, depth, active, ancestor, count, declared)
+                y += u(38)
         self.sidebar.configure(scrollregion=(0, 0, width, max(height, y + u(24))))
         self._render_footer()
 
@@ -1116,9 +1523,14 @@ class KbDesktopApp(tk.Tk):
         self.footer_hitboxes.clear()
         u = self._u
         width = max(int(self.sidebar_footer.winfo_width()), u(SIDEBAR_WIDTH))
-        height = max(int(self.sidebar_footer.winfo_height()), u(104))
+        height = max(int(self.sidebar_footer.winfo_height()), u(146))
         self.sidebar_footer.create_rectangle(0, 0, width, height, fill=SIDEBAR, outline=SIDEBAR, tags="footer")
         self.sidebar_footer.create_line(u(34), 0, width - u(40), 0, fill=LINE, tags="footer")
+        if self._active_organization_sources():
+            self._footer_row(self.sidebar_footer, u(28), u(14), width - u(32), self._text("organization_panel"), "organization")
+            self._footer_row(self.sidebar_footer, u(28), u(56), width - u(32), self._text("settings"), "settings")
+            self._footer_row(self.sidebar_footer, u(28), u(98), width - u(32), self._text("about"), "about")
+            return
         self._footer_row(self.sidebar_footer, u(28), u(14), width - u(32), self._text("settings"), "settings")
         self._footer_row(self.sidebar_footer, u(28), u(56), width - u(32), self._text("about"), "about")
 
@@ -1131,6 +1543,36 @@ class KbDesktopApp(tk.Tk):
     def searching(self, value: str) -> None:
         self._searching = value
 
+    def _section_row(self, x1: int, y1: int, x2: int, label: str, section: str, *, active: bool) -> None:
+        u = self._u
+        y2 = y1 + u(36)
+        expanded = section in self.expanded_sidebar_sections
+        if active:
+            self._round_rect(self.sidebar, x1, y1, x2, y2, u(10), fill="#f7f3f5", tags="chrome")
+            self.sidebar.create_line(x1 - u(8), y1 + u(8), x1 - u(8), y2 - u(8), fill=ACCENT, width=max(1, u(2)), tags="chrome")
+        icon = {"status": "status", "type": "type", "source": "cards", "paths": "paths"}.get(section, "route")
+        icon_color = ACCENT if active else MUTED
+        self._draw_sidebar_icon(self.sidebar, x1 + u(22), y1 + u(18), icon, icon_color, "chrome")
+        self.sidebar.create_text(
+            x1 + u(56),
+            y1 + u(18),
+            text=label,
+            anchor="w",
+            fill=ACCENT if active else TEXT,
+            font=self._font(14),
+            tags="chrome",
+        )
+        self.sidebar.create_text(
+            x2 - u(14),
+            y1 + u(18),
+            text="▾" if expanded else "›",
+            anchor="e",
+            fill=MUTED,
+            font=self._font(13, "bold"),
+            tags="chrome",
+        )
+        self.nav_hitboxes.append((x1, y1, x2, y2, "toggle-section", section))
+
     def _nav_row(self, x1: int, y1: int, x2: int, label: str, action: str, value: str, *, active: bool) -> None:
         u = self._u
         y2 = y1 + u(38)
@@ -1138,8 +1580,10 @@ class KbDesktopApp(tk.Tk):
             self._round_rect(self.sidebar, x1, y1, x2, y2, u(11), fill=SIDEBAR_ACTIVE, tags="chrome")
             self.sidebar.create_line(x1 - u(8), y1 + u(8), x1 - u(8), y2 - u(8), fill=ACCENT, width=max(1, u(2)), tags="chrome")
         icon = {"cards": "cards", "trusted": "trusted", "candidates": "candidates"}.get(action, "route")
+        if action == "status":
+            icon = {"trusted": "trusted", "candidate": "candidates", "deprecated": "deprecated"}.get(value, "status")
         if action == "type":
-            icon = "model" if value == "model" else "preference"
+            icon = {"model": "model", "preference": "preference", "heuristic": "heuristic", "fact": "fact"}.get(value, "type")
         icon_color = ACCENT if active else MUTED
         self._draw_sidebar_icon(self.sidebar, x1 + u(22), y1 + u(19), icon, icon_color, "chrome")
         self.sidebar.create_text(
@@ -1156,7 +1600,7 @@ class KbDesktopApp(tk.Tk):
     def _footer_row(self, canvas: tk.Canvas, x1: int, y1: int, x2: int, label: str, action: str) -> None:
         u = self._u
         y2 = y1 + u(36)
-        icon = "settings" if action == "settings" else "about"
+        icon = {"settings": "settings", "about": "about", "organization": "cards"}.get(action, "about")
         self._draw_sidebar_icon(canvas, x1 + u(22), y1 + u(18), icon, MUTED, "footer")
         canvas.create_text(x1 + u(54), y1 + u(18), text=label, anchor="w", fill=TEXT, font=self._font(14), tags="footer")
         self.footer_hitboxes.append((x1, y1, x2, y2, action))
@@ -1232,12 +1676,22 @@ class KbDesktopApp(tk.Tk):
             if x1 <= event.x <= x2 and y1 <= y <= y2:
                 if action == "cards":
                     self.load_route("")
+                elif action == "toggle-section":
+                    if value in self.expanded_sidebar_sections:
+                        self.expanded_sidebar_sections.remove(value)
+                    else:
+                        self.expanded_sidebar_sections.add(value)
+                    self._render_sidebar()
+                elif action == "status":
+                    self._load_status_view(value)
                 elif action == "trusted":
                     self._load_status_view("trusted")
                 elif action == "candidates":
                     self._load_status_view("candidate")
                 elif action == "type":
                     self._load_type_view(value)
+                elif action == "source":
+                    self._load_source_view(value)
                 elif action == "route":
                     self.load_route(value)
                 return
@@ -1246,13 +1700,17 @@ class KbDesktopApp(tk.Tk):
         for x1, y1, x2, y2, action in self.footer_hitboxes:
             if x1 <= event.x <= x2 and y1 <= event.y <= y2:
                 if action == "settings":
+                    if self._organization_window_loading and self._focus_organization_window():
+                        return
                     self._open_settings_window()
+                elif action == "organization":
+                    self._open_organization_window()
                 elif action == "about":
                     self._open_utility_window(
                         self._text("about_title"),
                         self._text("about_body").format(
                             github_url=PROJECT_GITHUB_URL,
-                            paypal=SUPPORT_PAYPAL,
+                            support_url=VOLUNTARY_SUPPORT_URL,
                         ),
                     )
                 return
@@ -1299,7 +1757,14 @@ class KbDesktopApp(tk.Tk):
             self.load_route(self.route)
             return "break"
         self.searching = query_text
-        payload = build_search_payload(self.repo_root, query=query_text, route_hint=self.route, top_k=24, language=self.language)
+        payload = build_search_payload(
+            self.repo_root,
+            query=query_text,
+            route_hint=self.route,
+            top_k=24,
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+        )
         self.deck = payload["results"]
         self.selected_index = -1
         self._card_selected_by_user = False
@@ -1311,26 +1776,58 @@ class KbDesktopApp(tk.Tk):
         return "break"
 
     def _load_status_view(self, status: str) -> None:
-        self.searching = status
-        payload = build_route_view_payload(self.repo_root, route="", language=self.language)
+        status = status.strip().lower()
+        self.route = ""
+        self.searching = f"status:{status}"
+        payload = build_route_view_payload(
+            self.repo_root,
+            route="",
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+        )
         self.deck = [card for card in payload.get("deck", []) if str(card.get("status") or "").lower() == status]
         self.selected_index = -1
         self._card_selected_by_user = False
         self.hovered_index = -1
-        self._route_heading = self._text("trusted") if status == "trusted" else self._text("candidates")
+        self._route_heading = _status_filter_label(status, self.language)
         self._route_subtitle = f"{len(self.deck)} {self._text('cards_suffix')}"
         self._render_sidebar()
         self._render_main()
 
     def _load_type_view(self, card_type: str) -> None:
         card_type = card_type.strip().lower()
+        self.route = ""
         self.searching = f"type:{card_type}"
-        payload = build_route_view_payload(self.repo_root, route="", language=self.language)
+        payload = build_route_view_payload(
+            self.repo_root,
+            route="",
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+        )
         self.deck = [card for card in payload.get("deck", []) if _card_type_value(card) == card_type]
         self.selected_index = -1
         self._card_selected_by_user = False
         self.hovered_index = -1
-        self._route_heading = self._text("models") if card_type == "model" else self._text("preferences")
+        self._route_heading = _type_filter_label(card_type, self.language)
+        self._route_subtitle = f"{len(self.deck)} {self._text('cards_suffix')}"
+        self._render_sidebar()
+        self._render_main()
+
+    def _load_source_view(self, source_kind: str) -> None:
+        source_kind = source_kind.strip().lower()
+        self.route = ""
+        self.searching = f"source:{source_kind}"
+        payload = build_source_view_payload(
+            self.repo_root,
+            source_kind,
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+        )
+        self.deck = payload.get("deck", [])
+        self.selected_index = -1
+        self._card_selected_by_user = False
+        self.hovered_index = -1
+        self._route_heading = _source_filter_label(source_kind, self.language)
         self._route_subtitle = f"{len(self.deck)} {self._text('cards_suffix')}"
         self._render_sidebar()
         self._render_main()
@@ -1338,7 +1835,12 @@ class KbDesktopApp(tk.Tk):
     def load_route(self, route: str) -> None:
         self.searching = ""
         self.route = route
-        payload = build_route_view_payload(self.repo_root, route=route, language=self.language)
+        payload = build_route_view_payload(
+            self.repo_root,
+            route=route,
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+        )
         self.children_by_route[route] = navigation_children(payload)
         self.expanded_routes.add(route)
         self.deck = payload.get("deck", [])
@@ -1385,7 +1887,7 @@ class KbDesktopApp(tk.Tk):
             anchor="nw",
             fill=TEXT,
             width=title_width,
-            font=("Segoe UI", f(23), "bold"),
+            font=("Segoe UI", f(21), "bold"),
         )
         title_bbox = self.main.bbox(title_item) or (content_left, title_top, title_right, title_top + u(44))
 
@@ -1534,6 +2036,29 @@ class KbDesktopApp(tk.Tk):
             fill=palette["muted"],
             font=("Segoe UI", f(6), "bold"),
         )
+        skill_label = _skill_badge_label(card, self.language)
+        if skill_label:
+            skill_x1 = x + u(16) + type_w + u(7)
+            skill_x2_limit = x + width - u(116)
+            skill_w = min(max(u(50), u(18) + len(skill_label) * u(6)), max(0, skill_x2_limit - skill_x1))
+            if skill_w >= u(42):
+                self._round_rect(
+                    self.main,
+                    skill_x1,
+                    y + u(16),
+                    skill_x1 + skill_w,
+                    y + u(31),
+                    u(8),
+                    fill=_blend_hex(palette.get("soft", palette["fill"]), "#ffffff", 0.18),
+                    outline=_blend_hex(palette["muted"], palette["fill"], 0.42),
+                )
+                self.main.create_text(
+                    skill_x1 + skill_w / 2,
+                    y + u(23),
+                    text=skill_label,
+                    fill=palette["muted"],
+                    font=("Segoe UI", f(6), "bold"),
+                )
         confidence = _confidence_label(card)
         if confidence:
             self.main.create_text(
@@ -1557,7 +2082,7 @@ class KbDesktopApp(tk.Tk):
                 anchor="nw",
                 fill=palette["deep"],
                 width=width - u(44),
-                font=self._font(13, "bold"),
+                font=self._font(13),
             )
 
         footer_y = y + height - u(48)
@@ -1565,7 +2090,7 @@ class KbDesktopApp(tk.Tk):
         body_step = max(u(16), min(u(20), width // 28))
         title_block_bottom = title_y + len(title_lines) * title_step
         body_top = title_block_bottom + u(16)
-        body_bottom = footer_y - u(12)
+        body_bottom = footer_y - u(26)
         available_body_lines = max(0, min(2, (body_bottom - body_top) // body_step))
         if available_body_lines:
             body_y = body_top
@@ -1579,6 +2104,18 @@ class KbDesktopApp(tk.Tk):
                     width=width - u(44),
                     font=self._font(10),
                 )
+
+        source_line = _short_text(_source_line(card, self.language), 54) if self._should_show_source_metadata(card) else ""
+        if source_line:
+            self.main.create_text(
+                x + u(22),
+                footer_y - u(16),
+                text=source_line,
+                anchor="nw",
+                fill=palette["muted"],
+                width=width - u(44),
+                font=("Segoe UI", f(7), "bold"),
+            )
 
         status = _status_label(card, self.language)
         self.main.create_line(x + u(18), footer_y, x + width - u(18), footer_y, fill=palette["line"])
@@ -1602,10 +2139,10 @@ class KbDesktopApp(tk.Tk):
         self.card_hitboxes.append((x, y, x + width, y + height, index))
 
     def _on_mousewheel(self, event: tk.Event[Any]) -> None:
-        self.main.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        self.main.yview_scroll(_wheel_scroll_units(event.delta, multiplier=MAIN_WHEEL_SCROLL_UNITS), "units")
 
     def _on_sidebar_mousewheel(self, event: tk.Event[Any]) -> None:
-        self.sidebar.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        self.sidebar.yview_scroll(_wheel_scroll_units(event.delta), "units")
 
     def _hit_card(self, event: tk.Event[Any]) -> int | None:
         x = int(self.main.canvasx(event.x))
@@ -1658,7 +2195,65 @@ class KbDesktopApp(tk.Tk):
                 return
         self._card_selected_by_user = True
         summary = self.deck[self.selected_index]
-        detail = build_card_detail_payload(self.repo_root, str(summary.get("id")), language=self.language)
+        summary_source = summary.get("source_info") if isinstance(summary.get("source_info"), dict) else None
+        if (summary_source or {}).get("kind") == "organization":
+            detail = build_card_detail_payload(
+                self.repo_root,
+                str(summary.get("id")),
+                language=self.language,
+                organization_sources=self._active_organization_sources(),
+                source_info=summary_source,
+                local_policy_allows_skill_auto_install=self._local_policy_allows_skill_auto_install(),
+            )
+            if detail is not None:
+                self._open_detail_window({**detail, "route_reason": summary.get("route_reason")})
+                try:
+                    adoption = adopt_organization_entry_by_source_info(
+                        self.repo_root,
+                        str(summary.get("id")),
+                        self._active_organization_sources(),
+                        source_info=summary_source,
+                    )
+                except Exception:
+                    adoption = {"ok": False}
+                if adoption.get("ok"):
+                    self._refresh_after_language_change()
+                return
+            try:
+                adoption = adopt_organization_entry_by_source_info(
+                    self.repo_root,
+                    str(summary.get("id")),
+                    self._active_organization_sources(),
+                    source_info=summary_source,
+                )
+            except Exception:
+                adoption = {"ok": False}
+            if adoption.get("ok"):
+                adopted_path = Path(str(adoption.get("path") or ""))
+                try:
+                    source_path = adopted_path.relative_to(self.repo_root).as_posix()
+                except ValueError:
+                    source_path = str(adopted_path)
+                detail = build_card_detail_payload(
+                    self.repo_root,
+                    str(adoption.get("entry_id") or summary.get("id")),
+                    language=self.language,
+                    organization_sources=self._active_organization_sources(),
+                    source_info={"kind": "local", "path": source_path.replace("/", "\\")},
+                    local_policy_allows_skill_auto_install=self._local_policy_allows_skill_auto_install(),
+                )
+                if detail is not None:
+                    self._open_detail_window({**detail, "route_reason": summary.get("route_reason")})
+                    self._refresh_after_language_change()
+                    return
+        detail = build_card_detail_payload(
+            self.repo_root,
+            str(summary.get("id")),
+            language=self.language,
+            organization_sources=self._active_organization_sources(),
+            source_info=summary_source,
+            local_policy_allows_skill_auto_install=self._local_policy_allows_skill_auto_install(),
+        )
         if detail is None:
             return
         self._open_detail_window({**detail, "route_reason": summary.get("route_reason")})
@@ -1675,13 +2270,15 @@ class KbDesktopApp(tk.Tk):
         window.grid_rowconfigure(2, weight=1)
 
         header_canvas = tk.Canvas(window, height=u(222), bg="#f7f7f9", highlightthickness=0)
-        header_canvas.grid(row=0, column=0, sticky="ew", padx=u(28), pady=(u(24), u(10)))
+        header_canvas.grid(row=0, column=0, sticky="ew", padx=u(28), pady=(u(24), 0))
 
         def render_header(event: tk.Event[Any] | None = None) -> None:
             header_canvas.delete("all")
             canvas_width = int(event.width if event else header_canvas.winfo_width()) or u(860)
             palette = _palette(card)
             banner_h = u(210)
+            drawer_y = banner_h - u(14)
+            header_canvas.create_rectangle(0, drawer_y, canvas_width, u(222), fill=BG, outline=BG)
             self._draw_gradient_surface(header_canvas, 0, 0, canvas_width, banner_h, u(26), palette)
             header_canvas.create_text(u(32), u(28), text=_card_type_label(card, self.language), anchor="nw", fill=palette["muted"], font=("Segoe UI", f(12), "bold"))
             header_canvas.create_text(
@@ -1697,9 +2294,18 @@ class KbDesktopApp(tk.Tk):
             confidence = _confidence_label(card)
             if confidence:
                 meta += f" · {self._text('confidence')} {confidence}"
+            source_meta = _source_line(card, self.language) if self._should_show_source_metadata(card) else ""
+            if source_meta:
+                meta += f" · {source_meta}"
             pill_right = u(32) + min(u(260), max(u(128), u(30) + len(meta) * u(8)))
             self._round_rect(header_canvas, u(32), banner_h - u(44), pill_right, banner_h - u(18), u(13), fill=palette["pill"])
-            header_canvas.create_text((u(32) + pill_right) / 2, banner_h - u(31), text=meta, fill=palette["pill_text"], font=("Segoe UI", f(10), "bold"))
+            header_canvas.create_text(
+                (u(32) + pill_right) / 2,
+                banner_h - u(31),
+                text=_short_text(meta, 74),
+                fill=palette["pill_text"],
+                font=("Segoe UI", f(10), "bold"),
+            )
 
         header_canvas.bind("<Configure>", render_header)
 
@@ -1722,7 +2328,7 @@ class KbDesktopApp(tk.Tk):
         detail_scroll = tk.Scrollbar(body_shell, orient="vertical", command=text.yview, width=u(8))
         detail_scroll.grid(row=0, column=1, sticky="ns")
         text.configure(yscrollcommand=detail_scroll.set)
-        text.tag_configure("heading", foreground=ACCENT, font=("Segoe UI", f(12), "bold"), spacing1=u(10), spacing3=u(4))
+        text.tag_configure("heading", foreground=TEXT, font=("Segoe UI", f(15), "bold"), spacing1=u(10), spacing3=u(4))
         text.tag_configure("body", foreground=TEXT, font=("Segoe UI", f(15)), spacing3=u(8))
         text.tag_configure("muted", foreground=MUTED, font=("Segoe UI", f(13)))
         text.tag_configure("mono", foreground=MUTED, font=("Consolas", f(12)))
@@ -1736,6 +2342,40 @@ class KbDesktopApp(tk.Tk):
         text.insert("end", f"{self._text('primary')}: {_route_label(card.get('domain_path'), self.language)}\n")
         text.insert("end", f"{self._text('also')}: {'; '.join(cross_routes) or '-'}\n")
         text.insert("end", f"{self._text('related')}: {'; '.join(card.get('related_cards') or []) or '-'}\n\n")
+        if self._should_show_source_metadata(card):
+            text.insert("end", f"{self._text('source')}\n", "heading")
+            source_line = _source_line(card, self.language)
+            source_info = card.get("source_info") if isinstance(card.get("source_info"), dict) else {}
+            organization_id = str(source_info.get("organization_id") or source_info.get("source_id") or "").strip()
+            text.insert("end", f"{source_line or '-'}\n", "muted")
+            text.insert(
+                "end",
+                f"{self._text('author')}: "
+                f"{_author_display_label(card.get('author_label'), self.language, source_kind=str(source_info.get('kind') or ''), organization_id=organization_id) or '-'}\n",
+                "muted",
+            )
+            text.insert("end", f"{card.get('path') or ''}\n\n", "mono")
+        skill_dependencies = card.get("skill_dependencies") or []
+        if skill_dependencies:
+            text.insert("end", f"{self._text('skill_dependencies')}\n", "heading")
+            for dependency in skill_dependencies:
+                if not isinstance(dependency, dict):
+                    continue
+                skill_id = str(dependency.get("id") or "").strip()
+                requirement = str(dependency.get("requirement") or "").strip()
+                registry_status = str(dependency.get("registry_status") or "missing").strip()
+                version = str(dependency.get("registry_version") or "").strip()
+                auto_install = dependency.get("auto_install") if isinstance(dependency.get("auto_install"), dict) else {}
+                eligible = bool(auto_install.get("eligible"))
+                auto_label = self._text("eligible") if eligible else self._text("not_eligible")
+                registry_label = registry_status if not version else f"{registry_status} {version}"
+                text.insert(
+                    "end",
+                    f"{skill_id} · {requirement} · {self._text('registry_status')}: {registry_label} · "
+                    f"{self._text('auto_install')}: {auto_label}\n",
+                    "muted",
+                )
+            text.insert("end", "\n")
         history = card.get("recent_history") or []
         if history:
             text.insert("end", f"{self._text('recent_history')}\n", "heading")
@@ -1744,7 +2384,6 @@ class KbDesktopApp(tk.Tk):
                 summary = normalize_text(event.get("task_summary") or event.get("rationale") or "-")
                 text.insert("end", f"{created_at} · {summary}\n", "muted")
             text.insert("end", "\n")
-        text.insert("end", f"{card.get('path') or ''}\n", "mono")
         text.configure(state="disabled")
         window.focus_set()
 
@@ -1752,38 +2391,168 @@ class KbDesktopApp(tk.Tk):
         if self.search_var.get() in {_ui_text(DEFAULT_LANGUAGE, "search"), _ui_text(ZH_CN, "search"), ""}:
             self.search_var.set(self._text("search"))
         current_search = self.searching
-        if current_search == "trusted":
-            self._load_status_view("trusted")
-            return
-        if current_search == "candidate":
-            self._load_status_view("candidate")
+        if current_search.startswith("status:"):
+            self._load_status_view(current_search.split(":", 1)[1])
             return
         if current_search.startswith("type:"):
             self._load_type_view(current_search.split(":", 1)[1])
+            return
+        if current_search.startswith("source:"):
+            self._load_source_view(current_search.split(":", 1)[1])
             return
         if current_search:
             self._perform_search(query=current_search)
             return
         self.load_route(self.route)
 
+    def _organization_window_exists(self) -> bool:
+        window = self._organization_window
+        if window is None:
+            return False
+        try:
+            return bool(window.winfo_exists())
+        except tk.TclError:
+            return False
+
+    def _clear_organization_window_state(self) -> None:
+        self._organization_window = None
+        self._organization_window_body = None
+        self._organization_window_loading = False
+
+    def _focus_organization_window(self) -> bool:
+        if not self._organization_window_exists():
+            self._clear_organization_window_state()
+            return False
+        assert self._organization_window is not None
+        self._organization_window.lift()
+        self._organization_window.focus_set()
+        return True
+
+    def _organization_window_message(self) -> str:
+        sources = self._active_organization_sources()
+        if not sources:
+            return self._text("organization_not_connected")
+
+        registry = build_skill_registry_payload(
+            sources,
+            local_policy_allows_auto_install=self._local_policy_allows_skill_auto_install(),
+        )
+        maintenance_status = maintenance_participation_status_from_settings(self.settings)
+        lines = [
+            f"{self._text('organization_source_count')}: {len(sources)}",
+            f"{self._text('organization_skills')}: "
+            f"{registry.get('counts', {}).get('approved', 0)} approved, "
+            f"{registry.get('counts', {}).get('candidate', 0)} candidate, "
+            f"{registry.get('counts', {}).get('rejected', 0)} rejected",
+            f"{self._text('maintenance')}: {maintenance_status.get('reason')}",
+            "",
+        ]
+
+        if registry.get("errors"):
+            lines.extend([f"{self._text('organization_invalid')}:"] + [f"- {error}" for error in registry.get("errors") or []])
+            lines.append("")
+
+        for source in sources:
+            org_id = str(source.get("organization_id") or source.get("id") or "").strip()
+            org_path = Path(str(source.get("path") or source.get("local_path") or ""))
+            commit = str(source.get("source_commit") or "").strip()[:7]
+            label = org_id if not commit else f"{org_id} @ {commit}"
+            report = build_organization_maintenance_report(org_path, repo_root=self.repo_root, organization_id=org_id)
+            lines.append(label)
+            if not report.get("ok"):
+                lines.append(f"- {self._text('organization_invalid')}")
+                continue
+            lines.append(f"- trusted: {report.get('trusted_count', 0)}")
+            lines.append(f"- candidate: {report.get('candidate_count', 0)}")
+            lines.append(f"- skills: {report.get('skill_count', 0)}")
+            lines.append(f"- outbox: {report.get('outbox_count', 0)}")
+            recommendations = report.get("recommendations") or []
+            if recommendations:
+                lines.append(f"- {self._text('recommendations')}: {', '.join(str(item) for item in recommendations[:5])}")
+            lines.append("")
+
+        return "\n".join(lines).strip()
+
+    def _populate_organization_window(self) -> None:
+        if not self._organization_window_exists() or self._organization_window_body is None:
+            self._clear_organization_window_state()
+            return
+        try:
+            message = self._organization_window_message()
+        except Exception as exc:
+            message = f"{self._text('organization_invalid')}\n{exc}"
+        self._organization_window_body.configure(text=message)
+        if self._organization_window is not None:
+            try:
+                self._organization_window.grab_release()
+            except tk.TclError:
+                pass
+        self._organization_window_loading = False
+
+    def _open_organization_window(self) -> None:
+        if self._focus_organization_window():
+            return
+
+        window, body = self._create_utility_window(
+            self._text("organization_panel_title"),
+            self._text("organization_loading"),
+        )
+        self._organization_window = window
+        self._organization_window_body = body
+        self._organization_window_loading = True
+
+        def clear_state(event: tk.Event[Any]) -> None:
+            if event.widget is window:
+                try:
+                    window.grab_release()
+                except tk.TclError:
+                    pass
+                self._clear_organization_window_state()
+
+        window.bind("<Destroy>", clear_state, add="+")
+        try:
+            window.grab_set()
+        except tk.TclError:
+            pass
+        self.after(40, self._populate_organization_window)
+
     def _open_settings_window(self) -> None:
+        if self._organization_window_loading and self._focus_organization_window():
+            return
         window = tk.Toplevel(self)
         window.title(self._text("settings_title"))
         u = self._u
         f = self._f
-        window_width = u(620)
-        window_height = u(360)
+        window_width = u(740)
+        screen_height = self.winfo_screenheight()
+        window_height = min(u(700), max(u(560), screen_height - u(80)))
         x = self.winfo_rootx() + max(u(80), (self.winfo_width() - window_width) // 2)
-        y = self.winfo_rooty() + max(u(80), (self.winfo_height() - window_height) // 3)
+        y = self.winfo_rooty() + max(u(40), (self.winfo_height() - window_height) // 4)
         window.geometry(f"{window_width}x{window_height}+{x}+{y}")
-        window.minsize(u(540), u(320))
+        window.minsize(u(640), min(u(560), window_height))
         window.transient(self)
         window.configure(bg="#f7f7f9")
         window.grid_columnconfigure(0, weight=1)
+        window.grid_rowconfigure(0, weight=1)
 
-        shell = tk.Frame(window, bg="#f7f7f9")
-        shell.grid(row=0, column=0, sticky="nsew", padx=u(34), pady=u(30))
+        body_canvas = tk.Canvas(window, bg="#f7f7f9", highlightthickness=0)
+        body_canvas.grid(row=0, column=0, sticky="nsew", padx=u(34), pady=(u(30), u(12)))
+        body_scrollbar = ttk.Scrollbar(window, orient="vertical", command=body_canvas.yview)
+        body_scrollbar.grid(row=0, column=1, sticky="ns", pady=(u(30), u(12)))
+        body_canvas.configure(yscrollcommand=body_scrollbar.set)
+
+        shell = tk.Frame(body_canvas, bg="#f7f7f9")
+        shell_window = body_canvas.create_window((0, 0), window=shell, anchor="nw")
         shell.grid_columnconfigure(0, weight=1)
+
+        def sync_settings_scroll_region(_event: tk.Event[Any] | None = None) -> None:
+            body_canvas.configure(scrollregion=body_canvas.bbox("all"))
+
+        def sync_settings_body_width(event: tk.Event[Any]) -> None:
+            body_canvas.itemconfigure(shell_window, width=event.width)
+
+        shell.bind("<Configure>", sync_settings_scroll_region)
+        body_canvas.bind("<Configure>", sync_settings_body_width)
 
         tk.Label(
             shell,
@@ -1800,7 +2569,7 @@ class KbDesktopApp(tk.Tk):
             fg=MUTED,
             anchor="w",
             justify="left",
-            wraplength=u(520),
+            wraplength=u(620),
             font=("Segoe UI", f(12)),
         ).grid(row=1, column=0, sticky="ew", pady=(u(8), u(20)))
 
@@ -1810,11 +2579,11 @@ class KbDesktopApp(tk.Tk):
         group.grid_columnconfigure(1, weight=1)
         tk.Label(
             group,
-            text="🌐",
+            text="Aa",
             bg=BG,
             fg=TEXT,
             anchor="center",
-            font=self._font(22),
+            font=self._font(18, "bold"),
         ).grid(row=0, column=0, sticky="n", padx=(u(18), u(10)), pady=(u(18), u(6)))
         tk.Label(
             group,
@@ -1831,13 +2600,30 @@ class KbDesktopApp(tk.Tk):
             fg=MUTED,
             anchor="w",
             justify="left",
-            wraplength=u(470),
+            wraplength=u(560),
             font=self._font(11),
         ).grid(row=1, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(12)))
 
         window.option_add("*TCombobox*Listbox.font", self._font(13))
+        window.option_add("*TCombobox*Listbox.background", BG)
+        window.option_add("*TCombobox*Listbox.foreground", TEXT)
+        window.option_add("*TCombobox*Listbox.selectBackground", "#ececf1")
+        window.option_add("*TCombobox*Listbox.selectForeground", TEXT)
         style = ttk.Style(window)
-        style.configure("Khaos.TCombobox", font=self._font(13), padding=u(8))
+        style.configure("Khaos.TCombobox", font=self._font(13), padding=(u(10), u(8), u(8), u(8)), arrowsize=u(18))
+
+        def configure_combo_popup(combo: ttk.Combobox) -> None:
+            try:
+                popdown = combo.tk.call("ttk::combobox::PopdownWindow", combo)
+                listbox = f"{popdown}.f.l"
+                combo.tk.call(listbox, "configure", "-font", self._font(13), "-activestyle", "none")
+                combo.tk.call(listbox, "configure", "-selectborderwidth", 0, "-borderwidth", u(6))
+            except tk.TclError:
+                return
+
+        def bind_combo_popup(combo: ttk.Combobox) -> None:
+            combo.configure(postcommand=lambda widget=combo: configure_combo_popup(widget))
+
         language_combo = ttk.Combobox(
             group,
             textvariable=language_display_var,
@@ -1845,16 +2631,218 @@ class KbDesktopApp(tk.Tk):
             state="readonly",
             style="Khaos.TCombobox",
             font=self._font(13),
+            height=4,
         )
         language_combo.grid(row=2, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(18)), ipady=u(4))
+        bind_combo_popup(language_combo)
 
-        actions = tk.Frame(shell, bg="#f7f7f9")
-        actions.grid(row=3, column=0, sticky="e")
+        organization = self.settings.get("organization", {}) if isinstance(self.settings.get("organization"), dict) else {}
+        mode_display_var = tk.StringVar(value=_mode_display(str(self.settings.get("mode") or PERSONAL_MODE), self.language))
+        repo_url_var = tk.StringVar(value=str(organization.get("repo_url") or ""))
+        maintenance_display_var = tk.StringVar(
+            value=_maintenance_display(
+                bool(organization.get("organization_maintenance_requested", organization.get("maintainer_mode_requested"))),
+                self.language,
+            )
+        )
 
-        def save_language() -> None:
-            self.language = _language_from_display(language_display_var.get())
-            self.settings["language"] = self.language
-            save_desktop_settings(self.repo_root, self.settings)
+        def organization_status_text(payload: dict[str, Any]) -> str:
+            if payload.get("validated"):
+                commit = str(payload.get("last_sync_commit") or "").strip()[:7]
+                suffix = f" @ {commit}" if commit else ""
+                return f"{self._text('organization_connected')}: {payload.get('organization_id')}{suffix}"
+            message = str(payload.get("validation_message") or "").strip()
+            return message or self._text("organization_not_connected")
+
+        status_var = tk.StringVar(value=organization_status_text(organization))
+
+        def set_status(message: str) -> None:
+            status_var.set(message)
+
+        org_group = tk.Frame(shell, bg=BG, highlightbackground=LINE, highlightthickness=1)
+        org_group.grid(row=3, column=0, sticky="ew", pady=(0, u(24)))
+        org_group.grid_columnconfigure(1, weight=1)
+        tk.Label(
+            org_group,
+            text="KB",
+            bg=BG,
+            fg=TEXT,
+            anchor="center",
+            font=self._font(16, "bold"),
+        ).grid(row=0, column=0, sticky="n", padx=(u(18), u(10)), pady=(u(18), u(6)))
+        tk.Label(
+            org_group,
+            text=self._text("mode"),
+            bg=BG,
+            fg=TEXT,
+            anchor="w",
+            font=self._font(15, "bold"),
+        ).grid(row=0, column=1, sticky="ew", padx=(0, u(18)), pady=(u(18), u(2)))
+        mode_combo = ttk.Combobox(
+            org_group,
+            textvariable=mode_display_var,
+            values=[
+                _mode_display(PERSONAL_MODE, self.language),
+                _mode_display(ORGANIZATION_MODE, self.language),
+            ],
+            state="readonly",
+            style="Khaos.TCombobox",
+            font=self._font(13),
+            height=4,
+        )
+        mode_combo.grid(row=1, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(8)), ipady=u(4))
+        bind_combo_popup(mode_combo)
+        tk.Label(
+            org_group,
+            text=self._text("mode_hint"),
+            bg=BG,
+            fg=MUTED,
+            anchor="w",
+            justify="left",
+            wraplength=u(560),
+            font=self._font(10),
+        ).grid(row=2, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(12)))
+        tk.Label(
+            org_group,
+            text=self._text("organization_repo_url"),
+            bg=BG,
+            fg=TEXT,
+            anchor="w",
+            font=self._font(12),
+        ).grid(row=3, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(6)))
+        repo_entry = tk.Entry(
+            org_group,
+            textvariable=repo_url_var,
+            relief="flat",
+            bg="#f7f7f9",
+            fg=TEXT,
+            insertbackground=TEXT,
+            borderwidth=0,
+            font=self._font(12),
+        )
+        repo_entry.grid(row=4, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(8)), ipady=u(8))
+        repo_hint_label = tk.Label(
+            org_group,
+            text=self._text("organization_repo_hint"),
+            bg=BG,
+            fg=MUTED,
+            anchor="w",
+            justify="left",
+            wraplength=u(560),
+            font=self._font(10),
+        )
+        repo_hint_label.grid(row=5, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(12)))
+        tk.Label(
+            org_group,
+            text=self._text("maintainer_mode"),
+            bg=BG,
+            fg=TEXT,
+            anchor="w",
+            font=self._font(12),
+        ).grid(row=6, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(6)))
+        maintenance_combo = ttk.Combobox(
+            org_group,
+            textvariable=maintenance_display_var,
+            values=[
+                _maintenance_display(False, self.language),
+                _maintenance_display(True, self.language),
+            ],
+            state="readonly",
+            style="Khaos.TCombobox",
+            font=self._font(13),
+            height=4,
+        )
+        maintenance_combo.grid(row=7, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(8)), ipady=u(4))
+        bind_combo_popup(maintenance_combo)
+        tk.Label(
+            org_group,
+            text=self._text("maintainer_hint"),
+            bg=BG,
+            fg=MUTED,
+            anchor="w",
+            justify="left",
+            wraplength=u(560),
+            font=self._font(10),
+        ).grid(row=8, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(8)))
+        tk.Label(
+            org_group,
+            textvariable=status_var,
+            bg=BG,
+            fg=MUTED,
+            anchor="w",
+            justify="left",
+            wraplength=u(560),
+            font=self._font(10),
+        ).grid(row=9, column=1, sticky="ew", padx=(0, u(18)), pady=(0, u(18)))
+
+        def update_org_controls(_event: tk.Event[Any] | None = None) -> None:
+            selected_mode = _mode_from_display(mode_display_var.get(), self.language)
+            organization_selected = selected_mode == ORGANIZATION_MODE
+            repo_entry.configure(
+                state="normal" if organization_selected else "disabled",
+                bg="#f7f7f9" if organization_selected else "#ececf1",
+                fg=TEXT if organization_selected else MUTED,
+                disabledbackground="#ececf1",
+                disabledforeground=MUTED,
+            )
+            maintenance_combo.configure(state="readonly" if organization_selected else "disabled")
+            repo_hint_label.configure(fg=MUTED if organization_selected else "#a3a3aa")
+
+        mode_combo.bind("<<ComboboxSelected>>", update_org_controls)
+        update_org_controls()
+
+        actions = tk.Frame(window, bg="#f7f7f9")
+        actions.grid(row=1, column=0, sticky="e", padx=u(34), pady=(0, u(24)))
+
+        def save_settings() -> None:
+            selected_language = _language_from_display(language_display_var.get())
+            selected_mode = _mode_from_display(mode_display_var.get(), self.language)
+            maintenance_requested = selected_mode == ORGANIZATION_MODE and _maintenance_from_display(maintenance_display_var.get(), self.language)
+            next_organization = dict(organization)
+            next_organization["repo_url"] = repo_url_var.get().strip()
+            next_organization["organization_maintenance_requested"] = maintenance_requested
+            next_organization["maintainer_mode_requested"] = maintenance_requested
+
+            if selected_mode == ORGANIZATION_MODE:
+                previous_url = str(organization.get("repo_url") or "").strip()
+                previous_mirror = str(organization.get("local_mirror_path") or "").strip()
+                mirror_path = previous_mirror if previous_url == next_organization["repo_url"] else ""
+                set_status(self._text("organization_validating"))
+                window.update_idletasks()
+                result = connect_organization_source(
+                    self.repo_root,
+                    next_organization["repo_url"],
+                    local_mirror_path=mirror_path or None,
+                )
+                next_organization = dict(result["settings"])
+                next_organization["organization_maintenance_requested"] = maintenance_requested
+                next_organization["maintainer_mode_requested"] = maintenance_requested
+                if maintenance_requested and result.get("ok"):
+                    next_organization["organization_maintenance_status"] = "pending"
+                    next_organization["organization_maintenance_message"] = "GitHub cloud checks have not validated a maintenance proposal yet"
+                self.settings = {
+                    "language": selected_language,
+                    "mode": ORGANIZATION_MODE if result.get("ok") else PERSONAL_MODE,
+                    "organization": next_organization,
+                }
+                save_desktop_settings(self.repo_root, self.settings)
+                self.settings = load_desktop_settings(self.repo_root)
+                self.organization_sources = organization_sources_from_settings(self.settings)
+                if not result.get("ok"):
+                    message = str(next_organization.get("validation_message") or self._text("organization_invalid"))
+                    set_status(f"{self._text('organization_invalid')} {message}")
+                    return
+            else:
+                self.settings = {
+                    "language": selected_language,
+                    "mode": PERSONAL_MODE,
+                    "organization": next_organization,
+                }
+                save_desktop_settings(self.repo_root, self.settings)
+                self.settings = load_desktop_settings(self.repo_root)
+                self.organization_sources = organization_sources_from_settings(self.settings)
+
+            self.language = selected_language
             self._refresh_after_language_change()
             window.destroy()
 
@@ -1871,8 +2859,8 @@ class KbDesktopApp(tk.Tk):
         ).grid(row=0, column=0, padx=(0, u(10)))
         tk.Button(
             actions,
-            text=self._text("save"),
-            command=save_language,
+            text=self._text("validate_and_save"),
+            command=save_settings,
             relief="flat",
             bg=ACCENT,
             fg=BG,
@@ -1884,7 +2872,7 @@ class KbDesktopApp(tk.Tk):
         window.lift()
         window.focus_set()
 
-    def _open_utility_window(self, title: str, message: str) -> None:
+    def _create_utility_window(self, title: str, message: str) -> tuple[tk.Toplevel, tk.Label]:
         window = tk.Toplevel(self)
         window.title(title)
         u = self._u
@@ -1933,6 +2921,10 @@ class KbDesktopApp(tk.Tk):
         window.bind("<Escape>", lambda _event: window.destroy())
         window.lift()
         window.focus_set()
+        return window, body
+
+    def _open_utility_window(self, title: str, message: str) -> None:
+        self._create_utility_window(title, message)
 
     def _insert_detail_section(self, widget: tk.Text, label: str, value: Any) -> None:
         widget.insert("end", f"{label}\n", "heading")

--- a/local_kb/dream.py
+++ b/local_kb/dream.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from local_kb.adoption import card_exchange_hash, find_local_entry_by_exchange_hash
 from local_kb.common import parse_route_segments, utc_now_iso
 from local_kb.consolidate import APPLY_MODE_NONE, consolidate_history, sanitize_run_id
 from local_kb.consolidate_apply import build_auto_candidate_entry
@@ -575,6 +576,7 @@ def _create_dream_candidate(
 ) -> tuple[dict[str, Any] | None, str]:
     supporting_events = supporting_events_for_action(action, indexed_events)
     entry = build_auto_candidate_entry(
+        repo_root,
         action=action,
         supporting_events=supporting_events,
         run_id=run_id,
@@ -597,6 +599,10 @@ def _create_dream_candidate(
     if sources and isinstance(sources[0], dict):
         sources[0]["origin"] = "dream exploration"
         sources[0]["dream_mode"] = creation_mode
+
+    existing_same_hash = find_local_entry_by_exchange_hash(repo_root, card_exchange_hash(entry))
+    if existing_same_hash is not None:
+        return None, f"Candidate content hash already exists: {relative_repo_path(repo_root, existing_same_hash.path)}"
 
     target_path = candidate_dir(repo_root) / f"{entry['id']}.yaml"
     relative_target_path = relative_repo_path(repo_root, target_path)

--- a/local_kb/github_repo_config.py
+++ b/local_kb/github_repo_config.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any
+
+from local_kb.org_sources import _git_executable
+
+
+def parse_github_owner_repo(repo_url: str) -> tuple[str, str]:
+    text = str(repo_url or "").strip()
+    if text.endswith(".git"):
+        text = text[:-4]
+    if text.startswith("git@github.com:"):
+        text = text.removeprefix("git@github.com:")
+    elif text.startswith("https://github.com/"):
+        text = text.removeprefix("https://github.com/")
+    else:
+        match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/\s]+)", text)
+        if not match:
+            return "", ""
+        return match.group("owner"), match.group("repo").removesuffix(".git")
+    parts = [part for part in text.split("/") if part]
+    if len(parts) < 2:
+        return "", ""
+    return parts[0], parts[1]
+
+
+def build_branch_protection_payload(required_contexts: list[str]) -> dict[str, Any]:
+    return {
+        "required_status_checks": {
+            "strict": True,
+            "contexts": required_contexts,
+        },
+        "enforce_admins": False,
+        "required_pull_request_reviews": None,
+        "restrictions": None,
+        "required_linear_history": False,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+        "block_creations": False,
+        "required_conversation_resolution": False,
+        "lock_branch": False,
+        "allow_fork_syncing": True,
+    }
+
+
+def github_token_from_git_credential() -> str:
+    payload = "protocol=https\nhost=github.com\n\n"
+    result = subprocess.run(
+        [_git_executable(), "credential", "fill"],
+        input=payload,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    values: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values.get("password", "")
+
+
+def _github_json_request(method: str, url: str, token: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read().decode("utf-8")
+            return {"ok": 200 <= response.status < 300, "status": response.status, "body": json.loads(raw) if raw else {}}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            body: Any = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = raw
+        return {"ok": False, "status": exc.code, "body": body}
+    except OSError as exc:
+        return {"ok": False, "status": 0, "body": {"message": str(exc)}}
+
+
+def configure_github_org_kb_repository(
+    repo_url: str,
+    *,
+    token: str,
+    branch: str = "main",
+    required_contexts: list[str] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    owner, repo = parse_github_owner_repo(repo_url)
+    if not owner or not repo:
+        return {"ok": False, "errors": ["repo_url is not a GitHub repository URL"], "steps": []}
+    if not token and not dry_run:
+        return {"ok": False, "errors": ["GitHub token is required"], "steps": []}
+
+    contexts = required_contexts or ["organization-kb-checks"]
+    protection_payload = build_branch_protection_payload(contexts)
+    steps = [
+        {
+            "name": "enable-auto-merge",
+            "method": "PATCH",
+            "url": f"https://api.github.com/repos/{owner}/{repo}",
+            "payload": {"allow_auto_merge": True},
+        },
+        {
+            "name": "protect-default-branch",
+            "method": "PUT",
+            "url": f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}/protection",
+            "payload": protection_payload,
+        },
+    ]
+    if dry_run:
+        return {"ok": True, "dry_run": True, "owner": owner, "repo": repo, "branch": branch, "steps": steps, "errors": []}
+
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for step in steps:
+        result = _github_json_request(step["method"], step["url"], token, step["payload"])
+        results.append({"name": step["name"], **result})
+        if not result.get("ok"):
+            message = result.get("body", {}).get("message") if isinstance(result.get("body"), dict) else result.get("body")
+            errors.append(f"{step['name']} failed: {message or result.get('status')}")
+
+    return {
+        "ok": not errors,
+        "dry_run": False,
+        "owner": owner,
+        "repo": repo,
+        "branch": branch,
+        "steps": results,
+        "errors": errors,
+    }

--- a/local_kb/install.py
+++ b/local_kb/install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -9,6 +10,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from local_kb.card_ids import load_or_create_installation_id
 from local_kb.common import utc_now_iso
 from local_kb.config import (
     KB_ROOT_ENV_VAR,
@@ -22,6 +24,8 @@ from local_kb.config import (
 
 GLOBAL_SKILL_NAME = "predictive-kb-preflight"
 GLOBAL_SKILL_ROOT = Path("skills") / GLOBAL_SKILL_NAME
+GLOBAL_SKILLS_ROOT = Path("skills")
+REPO_SKILLS_ROOT = Path(".agents") / "skills"
 TEMPLATE_ROOT = Path("templates") / GLOBAL_SKILL_NAME
 AUTOMATIONS_ROOT = Path("automations")
 GLOBAL_AGENTS_FILENAME = "AGENTS.md"
@@ -35,13 +39,49 @@ AUTOMATION_REASONING_EFFORT_ENV_VAR = "CODEX_KB_AUTOMATION_REASONING_EFFORT"
 AUTOMATION_FALLBACK_MODEL = "gpt-5.5"
 AUTOMATION_FALLBACK_REASONING_EFFORT = "xhigh"
 REASONING_EFFORT_ORDER = ("none", "minimal", "low", "medium", "high", "xhigh")
+AUTOMATION_DAILY_BYDAY = "SU,MO,TU,WE,TH,FR,SA"
+ORG_CONTRIBUTE_WINDOW = (10 * 60, 13 * 60 + 59)
+ORG_MAINTENANCE_WINDOW = (14 * 60, 16 * 60)
+MAINTENANCE_SKILL_SPECS = (
+    {
+        "name": "kb-sleep-maintenance",
+        "automation_id": "kb-sleep",
+        "prompt_marker": "MAINTENANCE_PROMPT.md",
+    },
+    {
+        "name": "kb-dream-pass",
+        "automation_id": "kb-dream",
+        "prompt_marker": "DREAM_PROMPT.md",
+    },
+    {
+        "name": "kb-architect-pass",
+        "automation_id": "kb-architect",
+        "prompt_marker": "ARCHITECT_PROMPT.md",
+    },
+    {
+        "name": "kb-organization-contribute",
+        "automation_id": "kb-org-contribute",
+        "prompt_marker": "scripts/kb_org_outbox.py",
+    },
+    {
+        "name": "kb-organization-maintenance",
+        "automation_id": "kb-org-maintenance",
+        "prompt_marker": "scripts/kb_org_maintainer.py",
+    },
+)
+MAINTENANCE_SKILL_NAMES = tuple(item["name"] for item in MAINTENANCE_SKILL_SPECS)
 
 SLEEP_AUTOMATION_PROMPT = (
-    "Run the repository's local KB sleep-maintenance pass for this workspace. Use PROJECT_SPEC.md, "
+    "Use $kb-sleep-maintenance to run the repository's local KB sleep-maintenance pass for this workspace. "
+    "Use PROJECT_SPEC.md, "
     "docs/maintenance_runbook.md, and .agents/skills/local-kb-retrieve/MAINTENANCE_PROMPT.md as the "
     "authoritative guides. First write a visible sleep execution plan with checkpoint statuses, start with a "
     "sleep self-preflight search against system/knowledge-library/maintenance, then run proposal mode, inspect "
-    "taxonomy and route gaps, review candidate route quality by preferring functional "
+    "taxonomy and route gaps, run a mandatory similar-card merge checkpoint, run a mandatory overloaded-card "
+    "split checkpoint, run an organization Skill bundle consolidation checkpoint that groups imported read-only "
+    "Skills by bundle_id and keeps only the latest approved version by version_time, record skip-with-reason "
+    "decisions when merge, split, or Skill replacement is not safe, review "
+    "candidate route quality by preferring functional "
     "domain paths over project-name roots, allow the current low-risk new-candidate, related-card, cross-index, "
     "AI-authored semantic-review, and AI-authored i18n apply paths when clearly eligible, "
     "require future utility before auto-creating candidate cards, require semantic-review utility assessments, "
@@ -60,7 +100,8 @@ SLEEP_AUTOMATION_PROMPT = (
 )
 
 DREAM_AUTOMATION_PROMPT = (
-    "Run one bounded local KB dream-mode pass for this workspace. Use PROJECT_SPEC.md, docs/dream_runbook.md, "
+    "Use $kb-dream-pass to run one bounded local KB dream-mode pass for this workspace. "
+    "Use PROJECT_SPEC.md, docs/dream_runbook.md, "
     "and .agents/skills/local-kb-retrieve/DREAM_PROMPT.md as the authoritative guides. Run "
     "`python .agents/skills/local-kb-retrieve/scripts/kb_dream.py --json --sleep-cooldown-minutes 45`, "
     "inspect the generated preflight, plan, opportunity, experiment, execution-plan, "
@@ -73,7 +114,8 @@ DREAM_AUTOMATION_PROMPT = (
 )
 
 ARCHITECT_AUTOMATION_PROMPT = (
-    "Run one KB Architect mechanism-maintenance pass for this workspace. Use PROJECT_SPEC.md, "
+    "Use $kb-architect-pass to run one KB Architect mechanism-maintenance pass for this workspace. "
+    "Use PROJECT_SPEC.md, "
     "docs/architecture_runbook.md, and .agents/skills/local-kb-retrieve/ARCHITECT_PROMPT.md as the "
     "authoritative guides. Before the first stateful command, write a visible Architect execution plan with "
     "checkpoint statuses and include every required checkpoint; do not skip any checkpoint silently. Start with "
@@ -92,12 +134,61 @@ ARCHITECT_AUTOMATION_PROMPT = (
     "postflight observation status, and watching items left for long observation."
 )
 
+ORG_CONTRIBUTE_AUTOMATION_PROMPT = (
+    "Use $kb-organization-contribute to run one settings-gated organization KB contribution pass for this "
+    "workspace. Use PROJECT_SPEC.md, docs/organization_mode_plan.md, and .agents/skills/local-kb-retrieve/SKILL.md "
+    "as the authoritative guides. Start by reading .local/khaos_brain_desktop_settings.json through "
+    "scripts/kb_org_outbox.py --automation; if the desktop settings are personal mode, missing, unvalidated, or not "
+    "connected to a validated organization repository, return a successful no-op. When organization mode is valid, "
+    "run KB preflight against system/knowledge-library/organization, then export only shareable public model and "
+    "heuristic cards through the content-hash-gated outbox. Respect prior download hashes, prior upload hashes, "
+    "current local card hashes, current organization repository hashes, and current import hashes; do not export "
+    "private cards, personal preferences, credentials, raw local paths, or raw machine identifiers. When cards "
+    "depend on local Skills, upload card-bound Skill bundles with bundle_id, content_hash, version_time, "
+    "original_author, readonly_when_imported, and update_policy=original_author_only; if several local cards point "
+    "at the same bundle_id, upload the local latest version for that bundle rather than an older card-carried copy. Use "
+    "`python scripts/kb_org_outbox.py --automation` for the safe scheduled pass; add --prepare-branch, commit, "
+    "or --push only when organization policy allows branch creation or remote submission. Run KB postflight after "
+    "any non-skipped pass, record a "
+    "structured observation, and report the settings gate, preflight entries, created and skipped proposal counts, "
+    "outbox path, branch or import proposal status, push or pull request URL if attempted, postflight path, and "
+    "errors."
+)
+
+ORG_MAINTENANCE_AUTOMATION_PROMPT = (
+    "Use $kb-organization-maintenance to run one settings-gated organization-level Sleep-like maintenance pass "
+    "for this workspace. Use PROJECT_SPEC.md, docs/organization_mode_plan.md, "
+    ".agents/skills/local-kb-retrieve/SKILL.md, and $organization-review as the authoritative guides. Start by "
+    "reading .local/khaos_brain_desktop_settings.json through scripts/kb_org_maintainer.py --automation; if the "
+    "desktop settings are personal mode, missing, unvalidated, or organization maintenance participation is not "
+    "requested, return a successful no-op. When participation is available for a validated organization "
+    "repository, run KB preflight against system/knowledge-library/organization, validate the organization "
+    "manifest, expected paths, imports lane, candidates lane, trusted lane, Skill registry, and current Git state, "
+    "then run the organization candidate intake checkpoint, content-hash checkpoint, mandatory organization "
+    "similar-card merge checkpoint, mandatory organization overloaded-card split checkpoint, candidate decision "
+    "checkpoint, Skill safety checkpoint, Skill bundle version checkpoint, and GitHub merge-readiness checkpoint. Inspect organization candidates, "
+    "imports, Skill registry entries, card-and-Skill bundles, privacy boundaries, and GitHub auto-merge readiness "
+    "using organization-review. Treat duplicate content hashes as maintenance signals and duplicate entry ids as "
+    "non-blocking handles. For card-bound Skill bundles, group by bundle_id, approve only original-author updates "
+    "on the same bundle, require sha256 content_hash and version_time, treat non-author changes as forks, and select "
+    "the latest approved version by version_time for organization distribution. Use candidate, approved, and rejected "
+    "as the first-pass Skill states; do not auto-install candidate, rejected, unknown, unpinned, or non-hash-verified "
+    "Skills. It is acceptable to skip applying a change when evidence, "
+    "safety, tooling, permissions, or scope is insufficient, but the inspection and recorded decision must still "
+    "happen. Run KB postflight after any non-skipped pass, record a structured observation, and report the settings "
+    "gate, participation status, preflight entries, manifest status, candidate and import counts, content-hash "
+    "duplicate decisions, organization merge checkpoint decisions, organization split checkpoint decisions, "
+    "candidate approval or rejection decisions, Skill dependency decisions, Skill bundle version decisions, GitHub "
+    "merge-readiness result, organization-review availability, recommendations, postflight path, and errors."
+)
+
 REPO_AUTOMATION_SPECS = (
     {
         "id": "kb-sleep",
         "name": "KB Sleep",
         "kind": "cron",
         "prompt": SLEEP_AUTOMATION_PROMPT,
+        "skill_name": "kb-sleep-maintenance",
         "status": "ACTIVE",
         "rrule": "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=12;BYMINUTE=0",
         "model_policy": AUTOMATION_MODEL_POLICY,
@@ -109,6 +200,7 @@ REPO_AUTOMATION_SPECS = (
         "name": "KB Dream",
         "kind": "cron",
         "prompt": DREAM_AUTOMATION_PROMPT,
+        "skill_name": "kb-dream-pass",
         "status": "ACTIVE",
         "rrule": "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=13;BYMINUTE=0",
         "model_policy": AUTOMATION_MODEL_POLICY,
@@ -120,8 +212,33 @@ REPO_AUTOMATION_SPECS = (
         "name": "KB Architect",
         "kind": "cron",
         "prompt": ARCHITECT_AUTOMATION_PROMPT,
+        "skill_name": "kb-architect-pass",
         "status": "ACTIVE",
         "rrule": "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=14;BYMINUTE=0",
+        "model_policy": AUTOMATION_MODEL_POLICY,
+        "reasoning_effort_policy": AUTOMATION_REASONING_EFFORT_POLICY,
+        "execution_environment": "local",
+    },
+    {
+        "id": "kb-org-contribute",
+        "name": "KB Organization Contribute",
+        "kind": "cron",
+        "prompt": ORG_CONTRIBUTE_AUTOMATION_PROMPT,
+        "skill_name": "kb-organization-contribute",
+        "status": "ACTIVE",
+        "jitter_window": ORG_CONTRIBUTE_WINDOW,
+        "model_policy": AUTOMATION_MODEL_POLICY,
+        "reasoning_effort_policy": AUTOMATION_REASONING_EFFORT_POLICY,
+        "execution_environment": "local",
+    },
+    {
+        "id": "kb-org-maintenance",
+        "name": "KB Organization Maintenance",
+        "kind": "cron",
+        "prompt": ORG_MAINTENANCE_AUTOMATION_PROMPT,
+        "skill_name": "kb-organization-maintenance",
+        "status": "ACTIVE",
+        "jitter_window": ORG_MAINTENANCE_WINDOW,
         "model_policy": AUTOMATION_MODEL_POLICY,
         "reasoning_effort_policy": AUTOMATION_REASONING_EFFORT_POLICY,
         "execution_environment": "local",
@@ -139,6 +256,15 @@ def default_local_appdata() -> Path:
 def global_skill_dir(codex_home: Path | None = None) -> Path:
     home = codex_home or default_codex_home()
     return home / GLOBAL_SKILL_ROOT
+
+
+def maintenance_skill_source_dir(repo_root: Path, skill_name: str) -> Path:
+    return repo_root / REPO_SKILLS_ROOT / skill_name
+
+
+def maintenance_skill_install_dir(skill_name: str, codex_home: Path | None = None) -> Path:
+    home = codex_home or default_codex_home()
+    return home / GLOBAL_SKILLS_ROOT / skill_name
 
 
 def codex_shell_bin_dir(path_env: str | None = None, local_appdata: Path | None = None) -> Path:
@@ -162,6 +288,37 @@ def automation_dir(codex_home: Path | None = None) -> Path:
 
 def automation_toml_path(automation_id: str, codex_home: Path | None = None) -> Path:
     return automation_dir(codex_home) / automation_id / "automation.toml"
+
+
+def _rrule_for_local_minute(total_minutes: int) -> str:
+    hour = max(0, min(23, int(total_minutes) // 60))
+    minute = max(0, min(59, int(total_minutes) % 60))
+    return f"FREQ=WEEKLY;BYDAY={AUTOMATION_DAILY_BYDAY};BYHOUR={hour};BYMINUTE={minute}"
+
+
+def _stable_window_minute(repo_root: Path, automation_id: str, window: tuple[int, int]) -> int:
+    start, end = int(window[0]), int(window[1])
+    if end < start:
+        raise ValueError(f"Invalid automation jitter window: {window}")
+    installation_id = load_or_create_installation_id(repo_root)
+    digest = hashlib.sha256(f"{installation_id}:{automation_id}".encode("utf-8")).digest()
+    offset = int.from_bytes(digest[:8], "big") % (end - start + 1)
+    return start + offset
+
+
+def automation_rrule_for_spec(spec: dict[str, Any], repo_root: Path) -> str:
+    window = spec.get("jitter_window")
+    if isinstance(window, tuple) and len(window) == 2:
+        return _rrule_for_local_minute(_stable_window_minute(repo_root, str(spec["id"]), window))
+    return str(spec["rrule"])
+
+
+def automation_time_window_label(spec: dict[str, Any]) -> str:
+    window = spec.get("jitter_window")
+    if not isinstance(window, tuple) or len(window) != 2:
+        return ""
+    start, end = int(window[0]), int(window[1])
+    return f"{start // 60:02d}:{start % 60:02d}-{end // 60:02d}:{end % 60:02d}"
 
 
 def global_agents_path(codex_home: Path | None = None) -> Path:
@@ -557,11 +714,12 @@ def install_codex_shell_tools(
 
 
 def _automation_spec_payload(
-    spec: dict[str, str],
+    spec: dict[str, Any],
     repo_root: Path,
     codex_home: Path | None = None,
 ) -> dict[str, Any]:
     runtime = resolve_automation_runtime(codex_home)
+    schedule_window = automation_time_window_label(spec)
     return {
         "version": 1,
         "id": spec["id"],
@@ -569,7 +727,9 @@ def _automation_spec_payload(
         "name": spec["name"],
         "prompt": spec["prompt"],
         "status": spec["status"],
-        "rrule": spec["rrule"],
+        "rrule": automation_rrule_for_spec(spec, repo_root),
+        "schedule_policy": "stable-jitter" if schedule_window else "fixed",
+        "schedule_window": schedule_window,
         "model": runtime["model"],
         "reasoning_effort": runtime["reasoning_effort"],
         "model_policy": spec.get("model_policy", runtime["model_policy"]),
@@ -603,6 +763,8 @@ def _write_automation_toml(path: Path, payload: dict[str, Any]) -> None:
         f"prompt = {json.dumps(payload['prompt'], ensure_ascii=False)}",
         f"status = {json.dumps(payload['status'], ensure_ascii=False)}",
         f"rrule = {json.dumps(payload['rrule'], ensure_ascii=False)}",
+        f"schedule_policy = {json.dumps(payload.get('schedule_policy', 'fixed'), ensure_ascii=False)}",
+        f"schedule_window = {json.dumps(payload.get('schedule_window', ''), ensure_ascii=False)}",
         f"model = {json.dumps(payload['model'], ensure_ascii=False)}",
         f"reasoning_effort = {json.dumps(payload['reasoning_effort'], ensure_ascii=False)}",
         f"model_policy = {json.dumps(payload['model_policy'], ensure_ascii=False)}",
@@ -613,6 +775,36 @@ def _write_automation_toml(path: Path, payload: dict[str, Any]) -> None:
         f"updated_at = {int(payload['updated_at'])}",
     ]
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def install_repo_maintenance_skills(repo_root: Path, codex_home: Path | None = None) -> list[dict[str, Any]]:
+    home = codex_home or default_codex_home()
+    installed: list[dict[str, Any]] = []
+    for spec in MAINTENANCE_SKILL_SPECS:
+        skill_name = spec["name"]
+        source = maintenance_skill_source_dir(repo_root, skill_name)
+        destination = maintenance_skill_install_dir(skill_name, home)
+        skill_path = source / "SKILL.md"
+        if not skill_path.exists():
+            raise FileNotFoundError(f"Repository-managed maintenance skill is missing: {skill_path}")
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(
+            source,
+            destination,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+        installed.append(
+            {
+                "name": skill_name,
+                "source_path": str(source),
+                "install_path": str(destination),
+                "skill_path": str(destination / "SKILL.md"),
+                "openai_path": str(destination / "agents" / "openai.yaml"),
+                "automation_id": spec["automation_id"],
+            }
+        )
+    return installed
 
 
 def install_repo_automations(repo_root: Path, codex_home: Path | None = None) -> list[dict[str, Any]]:
@@ -636,6 +828,8 @@ def install_repo_automations(repo_root: Path, codex_home: Path | None = None) ->
                 "name": payload["name"],
                 "path": str(path),
                 "rrule": payload["rrule"],
+                "schedule_policy": payload["schedule_policy"],
+                "schedule_window": payload["schedule_window"],
                 "model": payload["model"],
                 "reasoning_effort": payload["reasoning_effort"],
                 "model_policy": payload["model_policy"],
@@ -678,6 +872,7 @@ def install_codex_integration(
     )
     launcher_path.write_text(_read_template(repo_root, "kb_launch.py"), encoding="utf-8")
     openai_path.write_text(_read_template(repo_root, Path("agents") / "openai.yaml"), encoding="utf-8")
+    maintenance_skills = install_repo_maintenance_skills(repo_root=repo_root, codex_home=home)
     shell_tools = install_codex_shell_tools(
         shell_bin_dir=shell_bin_dir,
         git_executable=git_executable,
@@ -697,6 +892,8 @@ def install_codex_integration(
         "openai_path": str(openai_path),
         "global_agents_path": global_agents,
         "env_var_name": KB_ROOT_ENV_VAR,
+        "maintenance_skill_names": list(MAINTENANCE_SKILL_NAMES),
+        "maintenance_skills": maintenance_skills,
         "shell_tools": shell_tools,
         "automation_runtime": automation_runtime,
         "automation_ids": [item["id"] for item in automations],
@@ -722,6 +919,7 @@ def build_installation_check(
     manifest_root_raw = str(manifest.get("repo_root", "") or "").strip()
     env_value = os.environ.get(KB_ROOT_ENV_VAR, "").strip()
     managed_automations = manifest.get("automations", [])
+    managed_maintenance_skills = manifest.get("maintenance_skills", [])
     shell_tools_manifest = manifest.get("shell_tools", {}) if isinstance(manifest.get("shell_tools"), dict) else {}
 
     issues: list[str] = []
@@ -776,6 +974,11 @@ def build_installation_check(
             "Global skill default_prompt does not mention skill/plugin usage lessons as KB signals. "
             "Re-run the installer to refresh the installed prompt."
         )
+    if openai_text and "subagent/delegation usage lesson" not in openai_text:
+        issues.append(
+            "Global skill default_prompt does not mention subagent/delegation usage lessons as KB signals. "
+            "Re-run the installer to refresh the installed prompt."
+        )
     if not global_agents.exists():
         issues.append(
             f"Global AGENTS defaults file is missing: {global_agents}. "
@@ -809,6 +1012,11 @@ def build_installation_check(
             "Global AGENTS defaults do not mention skill/plugin usage lessons as KB signals. "
             "Re-run the installer to refresh the session-wide defaults."
         )
+    if global_agents_text and "subagent/delegation usage" not in global_agents_text:
+        issues.append(
+            "Global AGENTS defaults do not mention subagent/delegation usage lessons as KB signals. "
+            "Re-run the installer to refresh the session-wide defaults."
+        )
 
     shell_bin = Path(
         str(shell_tools_manifest.get("shell_bin_dir", "") or codex_shell_bin_dir())
@@ -830,8 +1038,69 @@ def build_installation_check(
             "Re-run the installer to restore stable ripgrep command resolution."
         )
 
-    automation_checks: list[dict[str, Any]] = []
     expected_repo_root = repo_root or (Path(manifest_root_raw) if manifest_root_raw else Path("."))
+    maintenance_skill_checks: list[dict[str, Any]] = []
+    for spec in MAINTENANCE_SKILL_SPECS:
+        skill_name = spec["name"]
+        source_dir = maintenance_skill_source_dir(expected_repo_root, skill_name)
+        install_dir = maintenance_skill_install_dir(skill_name, home)
+        source_skill_path = source_dir / "SKILL.md"
+        install_skill_path = install_dir / "SKILL.md"
+        install_openai_path = install_dir / "agents" / "openai.yaml"
+        issues_for_skill: list[str] = []
+        if not source_skill_path.exists():
+            issues_for_skill.append(f"Repository maintenance skill source is missing: {source_skill_path}")
+        if not install_skill_path.exists():
+            issues_for_skill.append(f"Installed maintenance skill file is missing: {install_skill_path}")
+            skill_text = ""
+        else:
+            try:
+                skill_text = install_skill_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                issues_for_skill.append(f"Installed maintenance skill could not be read: {exc}")
+                skill_text = ""
+        if not install_openai_path.exists():
+            issues_for_skill.append(f"Installed maintenance skill openai.yaml is missing: {install_openai_path}")
+            skill_openai_text = ""
+        else:
+            try:
+                skill_openai_text = install_openai_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                issues_for_skill.append(f"Installed maintenance skill openai.yaml could not be read: {exc}")
+                skill_openai_text = ""
+        if skill_text:
+            if f"name: {skill_name}" not in skill_text:
+                issues_for_skill.append(f"Installed maintenance skill {skill_name} has the wrong frontmatter name.")
+            if "[TODO" in skill_text:
+                issues_for_skill.append(f"Installed maintenance skill {skill_name} still contains TODO scaffolding.")
+            if str(spec["prompt_marker"]) not in skill_text:
+                issues_for_skill.append(
+                    f"Installed maintenance skill {skill_name} is missing prompt marker {spec['prompt_marker']}."
+                )
+        if skill_openai_text:
+            if "allow_implicit_invocation: false" not in skill_openai_text:
+                issues_for_skill.append(
+                    f"Installed maintenance skill {skill_name} should disable implicit invocation."
+                )
+            if f"${skill_name}" not in skill_openai_text:
+                issues_for_skill.append(
+                    f"Installed maintenance skill {skill_name} default prompt should mention ${skill_name}."
+                )
+        if issues_for_skill:
+            issues.extend(issues_for_skill)
+        maintenance_skill_checks.append(
+            {
+                "name": skill_name,
+                "source_path": str(source_dir),
+                "install_path": str(install_dir),
+                "exists": install_skill_path.exists(),
+                "openai_exists": install_openai_path.exists(),
+                "automation_id": spec["automation_id"],
+                "issues": issues_for_skill,
+            }
+        )
+
+    automation_checks: list[dict[str, Any]] = []
     automation_runtime = resolve_automation_runtime(home)
     for spec in REPO_AUTOMATION_SPECS:
         expected = _automation_spec_payload(spec, expected_repo_root, codex_home=home)
@@ -861,6 +1130,14 @@ def build_installation_check(
                 issues_for_automation.append(
                     f"Automation {expected['id']} should use rrule {expected['rrule']}."
                 )
+            if str(payload.get("schedule_policy", "") or "") != expected["schedule_policy"]:
+                issues_for_automation.append(
+                    f"Automation {expected['id']} should record schedule_policy={expected['schedule_policy']}."
+                )
+            if str(payload.get("schedule_window", "") or "") != expected["schedule_window"]:
+                issues_for_automation.append(
+                    f"Automation {expected['id']} should record schedule_window={expected['schedule_window']}."
+                )
             if str(payload.get("model", "") or "") != expected["model"]:
                 issues_for_automation.append(
                     f"Automation {expected['id']} should use model={expected['model']} from policy={expected['model_policy']}."
@@ -888,6 +1165,11 @@ def build_installation_check(
                     f"Automation {expected['id']} should target cwds={expected['cwds']}."
                 )
             prompt_text = str(payload.get("prompt", "") or "")
+            expected_skill_name = str(spec.get("skill_name", "") or "")
+            if expected_skill_name and f"${expected_skill_name}" not in prompt_text:
+                issues_for_automation.append(
+                    f"Automation {expected['id']} prompt must explicitly invoke ${expected_skill_name}."
+                )
             required_prompt_markers = (
                 ".agents/skills/local-kb-retrieve",
                 "PROJECT_SPEC.md",
@@ -923,6 +1205,11 @@ def build_installation_check(
                     "checkpoint statuses",
                     "sleep self-preflight",
                     "system/knowledge-library/maintenance",
+                    "mandatory similar-card merge checkpoint",
+                    "mandatory overloaded-card split checkpoint",
+                    "organization Skill bundle consolidation checkpoint",
+                    "latest approved version by version_time",
+                    "skip-with-reason decisions",
                     "every safe checkpoint",
                     "supported low-risk repairs",
                     "rerun the relevant validation",
@@ -954,6 +1241,53 @@ def build_installation_check(
                         issues_for_automation.append(
                             f"Automation kb-architect prompt is missing architect lifecycle marker: {marker}"
                         )
+            if expected["id"] == "kb-org-contribute":
+                for marker in (
+                    "scripts/kb_org_outbox.py",
+                    "desktop settings",
+                    "organization mode",
+                    "validated organization repository",
+                    "successful no-op",
+                    "KB preflight",
+                    "content-hash-gated outbox",
+                    "prior download hashes",
+                    "prior upload hashes",
+                    "KB postflight",
+                ):
+                    if marker not in prompt_text:
+                        issues_for_automation.append(
+                            f"Automation kb-org-contribute prompt is missing organization contribution marker: {marker}"
+                        )
+            if expected["id"] == "kb-org-maintenance":
+                for marker in (
+                    "scripts/kb_org_maintainer.py",
+                    "organization-level Sleep-like maintenance",
+                    "desktop settings",
+                    "organization maintenance participation",
+                    "successful no-op",
+                    "KB preflight",
+                    "organization candidate intake checkpoint",
+                    "content-hash checkpoint",
+                    "mandatory organization similar-card merge checkpoint",
+                    "mandatory organization overloaded-card split checkpoint",
+                    "candidate decision checkpoint",
+                    "Skill safety checkpoint",
+                    "Skill bundle version checkpoint",
+                    "GitHub merge-readiness checkpoint",
+                    "organization-review",
+                    "Skill registry",
+                    "duplicate content hashes",
+                    "duplicate entry ids",
+                    "bundle_id",
+                    "original-author updates",
+                    "latest approved version by version_time",
+                    "do not auto-install",
+                    "KB postflight",
+                ):
+                    if marker not in prompt_text:
+                        issues_for_automation.append(
+                            f"Automation kb-org-maintenance prompt is missing organization maintenance marker: {marker}"
+                        )
         if issues_for_automation:
             issues.extend(issues_for_automation)
         automation_checks.append(
@@ -961,17 +1295,26 @@ def build_installation_check(
                 "id": spec["id"],
                 "path": str(path),
                 "exists": path.exists(),
+                "rrule": expected["rrule"],
+                "schedule_policy": expected["schedule_policy"],
+                "schedule_window": expected["schedule_window"],
                 "issues": issues_for_automation,
             }
         )
 
     if not managed_automations:
         warnings.append(
-            "Install manifest does not record the repository-managed sleep/dream/architect automations. "
+            "Install manifest does not record the repository-managed KB automations. "
             "Re-run the installer to refresh automation setup."
+        )
+    if not managed_maintenance_skills:
+        warnings.append(
+            "Install manifest does not record the repository-managed KB skills. "
+            "Re-run the installer to refresh skill setup."
         )
 
     automation_issue_map = {item["id"]: item["issues"] for item in automation_checks}
+    maintenance_skill_ok = all(not item["issues"] for item in maintenance_skill_checks)
     global_skill_present = skill_path.exists() and launcher_path.exists() and openai_path.exists()
     global_skill_implicit = bool(openai_text and "allow_implicit_invocation: true" in openai_text)
     global_skill_postflight = bool(
@@ -980,6 +1323,7 @@ def build_installation_check(
         and "required default preflight" in openai_text
     )
     global_skill_skill_usage = bool(openai_text and "skill/plugin usage lesson" in openai_text)
+    global_skill_subagent_usage = bool(openai_text and "subagent/delegation usage lesson" in openai_text)
     global_agents_present = global_agents.exists()
     global_agents_managed = bool(
         global_agents_text
@@ -989,9 +1333,13 @@ def build_installation_check(
     global_agents_preflight = bool(global_agents_text and "$predictive-kb-preflight" in global_agents_text)
     global_agents_postflight = bool(global_agents_text and "explicit KB postflight check" in global_agents_text)
     global_agents_skill_usage = bool(global_agents_text and "skill/plugin usage" in global_agents_text)
+    global_agents_subagent_usage = bool(global_agents_text and "subagent/delegation usage" in global_agents_text)
     kb_sleep_ok = not automation_issue_map.get("kb-sleep")
     kb_dream_ok = not automation_issue_map.get("kb-dream")
     kb_architect_ok = not automation_issue_map.get("kb-architect")
+    kb_org_contribute_ok = not automation_issue_map.get("kb-org-contribute")
+    kb_org_maintenance_ok = not automation_issue_map.get("kb-org-maintenance")
+    automation_check_map = {item["id"]: item for item in automation_checks}
     codex_shell_tools_ok = git_shim_path.exists() and rg_path.exists()
     strong_defaults_ok = (
         global_skill_implicit
@@ -1001,6 +1349,9 @@ def build_installation_check(
         and global_agents_postflight
         and global_skill_skill_usage
         and global_agents_skill_usage
+        and global_skill_subagent_usage
+        and global_agents_subagent_usage
+        and maintenance_skill_ok
     )
     checklist = [
         _checklist_item(
@@ -1025,6 +1376,12 @@ def build_installation_check(
             "global_skill_skill_usage",
             "Global predictive KB prompt treats skill/plugin lessons as recordable KB signals",
             global_skill_skill_usage,
+            f"openai_path={openai_path}",
+        ),
+        _checklist_item(
+            "global_skill_subagent_usage",
+            "Global predictive KB prompt treats subagent/delegation lessons as recordable KB signals",
+            global_skill_subagent_usage,
             f"openai_path={openai_path}",
         ),
         _checklist_item(
@@ -1058,6 +1415,18 @@ def build_installation_check(
             f"global_agents_path={global_agents}",
         ),
         _checklist_item(
+            "global_agents_subagent_usage",
+            "Global AGENTS defaults treat subagent/delegation lessons as recordable KB signals",
+            global_agents_subagent_usage,
+            f"global_agents_path={global_agents}",
+        ),
+        _checklist_item(
+            "repo_maintenance_skills",
+            "Repository-managed KB maintenance and organization skills are installed",
+            maintenance_skill_ok,
+            "; ".join(f"{item['name']}={item['install_path']}" for item in maintenance_skill_checks),
+        ),
+        _checklist_item(
             "kb_sleep_automation",
             "KB Sleep automation is installed and matches the repository spec",
             kb_sleep_ok,
@@ -1074,6 +1443,26 @@ def build_installation_check(
             "KB Architect automation is installed and matches the repository spec",
             kb_architect_ok,
             f"path={automation_toml_path('kb-architect', home)}",
+        ),
+        _checklist_item(
+            "kb_org_contribute_automation",
+            "KB Organization Contribute automation is installed and matches the repository spec",
+            kb_org_contribute_ok,
+            (
+                f"path={automation_toml_path('kb-org-contribute', home)}; "
+                f"rrule={automation_check_map.get('kb-org-contribute', {}).get('rrule', '')}; "
+                f"window={automation_check_map.get('kb-org-contribute', {}).get('schedule_window', '')}"
+            ),
+        ),
+        _checklist_item(
+            "kb_org_maintenance_automation",
+            "KB Organization Maintenance automation is installed and matches the repository spec",
+            kb_org_maintenance_ok,
+            (
+                f"path={automation_toml_path('kb-org-maintenance', home)}; "
+                f"rrule={automation_check_map.get('kb-org-maintenance', {}).get('rrule', '')}; "
+                f"window={automation_check_map.get('kb-org-maintenance', {}).get('schedule_window', '')}"
+            ),
         ),
         _checklist_item(
             "codex_shell_tools",
@@ -1102,6 +1491,7 @@ def build_installation_check(
         "install_state_path": str(install_state_path(home)),
         "env_var_name": KB_ROOT_ENV_VAR,
         "env_var_value": env_value,
+        "maintenance_skill_names": list(MAINTENANCE_SKILL_NAMES),
         "shell_tools": {
             "shell_bin_dir": str(shell_bin),
             "git_shim_path": str(git_shim_path),
@@ -1109,6 +1499,7 @@ def build_installation_check(
         },
         "automation_runtime": automation_runtime,
         "checklist": checklist,
+        "maintenance_skill_checks": maintenance_skill_checks,
         "automation_checks": automation_checks,
         "issues": issues,
         "warnings": warnings,

--- a/local_kb/models.py
+++ b/local_kb/models.py
@@ -9,6 +9,7 @@ from typing import Any
 class Entry:
     path: Path
     data: dict[str, Any]
+    source: dict[str, Any] = field(default_factory=dict)
     score: float = 0.0
 
 
@@ -18,4 +19,3 @@ class RouteBranch:
     route: list[str]
     entry_ids: set[str] = field(default_factory=set)
     direct_entry_ids: set[str] = field(default_factory=set)
-

--- a/local_kb/org_automation.py
+++ b/local_kb/org_automation.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from local_kb.card_ids import installation_short_label
+from local_kb.feedback import build_observation, record_observation
+from local_kb.org_contribution import prepare_organization_import_branch
+from local_kb.org_maintenance import build_organization_maintenance_report
+from local_kb.org_outbox import build_organization_outbox, organization_outbox_dir
+from local_kb.search import search_entries
+from local_kb.settings import (
+    load_desktop_settings,
+    maintenance_participation_status_from_settings,
+    organization_sources_from_settings,
+)
+
+
+ORG_AUTOMATION_ROUTE = "system/knowledge-library/organization"
+
+
+def _preflight(repo_root: Path, *, query: str) -> dict[str, Any]:
+    results = search_entries(
+        repo_root,
+        query=query,
+        path_hint=ORG_AUTOMATION_ROUTE,
+        top_k=5,
+    )
+    return {
+        "route_hint": ORG_AUTOMATION_ROUTE,
+        "query": query,
+        "matched_entry_ids": [str(item.data.get("id") or item.path.stem) for item in results],
+        "matched_entry_count": len(results),
+    }
+
+
+def _record_postflight(
+    repo_root: Path,
+    *,
+    task_summary: str,
+    preflight: dict[str, Any],
+    outcome: str,
+    comment: str,
+    action_taken: str,
+    observed_result: str,
+    operational_use: str,
+    agent_name: str,
+    suggested_action: str = "none",
+) -> str:
+    observation = build_observation(
+        task_summary=task_summary,
+        route_hint=ORG_AUTOMATION_ROUTE,
+        entry_ids=",".join(preflight.get("matched_entry_ids", [])),
+        hit_quality="hit" if preflight.get("matched_entry_ids") else "none",
+        outcome=outcome,
+        comment=comment,
+        scenario="Scheduled organization KB automation ran against a locally configured organization source.",
+        action_taken=action_taken,
+        observed_result=observed_result,
+        operational_use=operational_use,
+        reuse_judgment="Reusable as an audit trail for organization KB automation behavior.",
+        suggested_action=suggested_action,
+        source_kind="automation",
+        agent_name=agent_name,
+        project_ref="organization-kb",
+        workspace_root=str(repo_root),
+    )
+    path = record_observation(repo_root, observation)
+    return str(path)
+
+
+def _first_organization_source(repo_root: Path) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any]]:
+    settings = load_desktop_settings(repo_root)
+    sources = organization_sources_from_settings(settings)
+    if not sources:
+        return {}, [], settings
+    return sources[0], sources, settings
+
+
+def run_organization_contribution(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    prepare_branch: bool = False,
+    contributor_id: str = "",
+    branch_name: str = "",
+    commit: bool = True,
+    push: bool = False,
+    remote: str = "origin",
+    base_branch: str = "main",
+    record_postflight: bool = True,
+) -> dict[str, Any]:
+    repo_root = Path(repo_root)
+    source, sources, settings = _first_organization_source(repo_root)
+    if not source:
+        return {
+            "ok": True,
+            "skipped": True,
+            "reason": "organization mode is not connected to a validated repository",
+            "settings_gate": {
+                "available": False,
+                "mode": str(settings.get("mode") or "personal"),
+                "organization_validated": bool(
+                    (settings.get("organization") if isinstance(settings.get("organization"), dict) else {}).get(
+                        "validated"
+                    )
+                ),
+            },
+            "settings_mode": str(settings.get("mode") or "personal"),
+            "preflight": {},
+            "postflight_recorded": False,
+        }
+
+    organization_id = str(source.get("organization_id") or "").strip()
+    preflight = _preflight(
+        repo_root,
+        query="organization contribution outbox card upload content hash skill dependency",
+    )
+    outbox = build_organization_outbox(
+        repo_root,
+        organization_id=organization_id,
+        dry_run=dry_run,
+        organization_sources=sources,
+    )
+    branch_result: dict[str, Any] = {"attempted": False}
+    if outbox.get("ok") and prepare_branch and not dry_run and int(outbox.get("created_count", 0) or 0) > 0:
+        branch_result = prepare_organization_import_branch(
+            Path(str(source.get("path") or "")),
+            organization_outbox_dir(repo_root, organization_id),
+            contributor_id=contributor_id or installation_short_label(repo_root),
+            branch_name=branch_name,
+            commit=commit,
+            push=push,
+            remote=remote,
+            base_branch=base_branch,
+        )
+        branch_result["attempted"] = True
+
+    ok = bool(outbox.get("ok")) and bool(branch_result.get("ok", True))
+    postflight_path = ""
+    if record_postflight and not dry_run:
+        postflight_path = _record_postflight(
+            repo_root,
+            task_summary="Organization KB contribution automation",
+            preflight=preflight,
+            outcome=(
+                f"created={outbox.get('created_count', 0)} skipped={outbox.get('skipped_count', 0)} "
+                f"branch_attempted={bool(branch_result.get('attempted'))}"
+            ),
+            comment="Organization contribution automation inspected local shareable cards and prepared organization proposals when eligible.",
+            action_taken="Read desktop organization settings, ran content-hash-gated organization outbox export, and optionally prepared an import branch.",
+            observed_result=f"Outbox created {outbox.get('created_count', 0)} proposal(s).",
+            operational_use="Use this audit event to confirm scheduled contribution automation is respecting organization-mode settings and content-hash dedupe.",
+            agent_name="kb-organization-contribute",
+        )
+
+    return {
+        "ok": ok,
+        "skipped": False,
+        "settings_gate": {
+            "available": True,
+            "mode": str(settings.get("mode") or "personal"),
+            "organization_validated": True,
+        },
+        "organization_id": organization_id,
+        "source": source,
+        "preflight": preflight,
+        "outbox": outbox,
+        "branch": branch_result,
+        "postflight_recorded": bool(postflight_path),
+        "postflight_path": postflight_path,
+    }
+
+
+def run_organization_maintenance(
+    repo_root: Path,
+    *,
+    record_postflight: bool = True,
+) -> dict[str, Any]:
+    repo_root = Path(repo_root)
+    settings = load_desktop_settings(repo_root)
+    participation = maintenance_participation_status_from_settings(settings)
+    sources = organization_sources_from_settings(settings)
+    if not participation.get("available") or not sources:
+        return {
+            "ok": True,
+            "skipped": True,
+            "reason": str(participation.get("reason") or "organization maintenance participation is not available"),
+            "settings_gate": {
+                "available": False,
+                "mode": str(settings.get("mode") or "personal"),
+                "organization_validated": bool(
+                    (settings.get("organization") if isinstance(settings.get("organization"), dict) else {}).get(
+                        "validated"
+                    )
+                ),
+                "maintenance_requested": bool(participation.get("requested")),
+            },
+            "participation": participation,
+            "preflight": {},
+            "postflight_recorded": False,
+        }
+
+    source = sources[0]
+    organization_id = str(source.get("organization_id") or "").strip()
+    preflight = _preflight(
+        repo_root,
+        query="organization maintenance review candidates skills merge split auto merge",
+    )
+    report = build_organization_maintenance_report(
+        Path(str(source.get("path") or "")),
+        repo_root=repo_root,
+        organization_id=organization_id,
+    )
+    postflight_path = ""
+    if record_postflight:
+        postflight_path = _record_postflight(
+            repo_root,
+            task_summary="Organization KB maintenance automation",
+            preflight=preflight,
+            outcome=(
+                f"candidate_count={report.get('candidate_count', 0)} "
+                f"skill_count={report.get('skill_count', 0)} "
+                f"recommendations={len(report.get('recommendations', []))}"
+            ),
+            comment="Organization maintenance automation inspected the validated organization mirror and produced a review report.",
+            action_taken="Read desktop organization maintenance settings, validated participation, then inspected the organization KB mirror with organization-review requirements.",
+            observed_result=f"Report recommendations: {', '.join(report.get('recommendations', [])) or 'none'}.",
+            operational_use="Use this audit event to confirm scheduled organization maintenance runs only on opted-in machines and leaves reviewable recommendations.",
+            agent_name="kb-organization-maintenance",
+        )
+
+    return {
+        "ok": bool(report.get("ok")),
+        "skipped": False,
+        "settings_gate": {
+            "available": True,
+            "mode": str(settings.get("mode") or "personal"),
+            "organization_validated": True,
+            "maintenance_requested": bool(participation.get("requested")),
+        },
+        "organization_id": organization_id,
+        "source": source,
+        "participation": participation,
+        "preflight": preflight,
+        "report": report,
+        "postflight_recorded": bool(postflight_path),
+        "postflight_path": postflight_path,
+    }

--- a/local_kb/org_checks.py
+++ b/local_kb/org_checks.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+from local_kb.adoption import card_exchange_hash
+from local_kb.org_sources import validate_organization_repo
+from local_kb.store import load_yaml_file
+
+
+LOW_RISK_PREFIXES = ("kb/candidates/", "kb/imports/", "skills/candidates/")
+PROTECTED_PREFIXES = ("kb/trusted/",)
+PROTECTED_FILES = {"khaos_org_kb.yaml", "skills/registry.yaml"}
+TEXT_SUFFIXES = {".yaml", ".yml", ".md", ".json", ".txt"}
+SKILL_REVIEW_STATES = {"candidate", "approved", "rejected"}
+SKILL_REQUIREMENTS = {"required", "recommended", "optional"}
+
+SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"(?im)^\s*(password|secret|api[_-]?key|access[_-]?token)\s*:\s*['\"]?[^'\"\s][^'\"]*"),
+)
+LOCAL_PATH_PATTERNS = (
+    re.compile(r"[A-Za-z]:\\Users\\"),
+    re.compile(r"/Users/[^/\s]+/"),
+    re.compile(r"/home/[^/\s]+/"),
+    re.compile(r"\.codex[\\/]+"),
+    re.compile(r"AppData\\"),
+)
+RAW_MACHINE_KEYS = {
+    "hardware_id",
+    "hardware_fingerprint",
+    "machine_id",
+    "device_id",
+    "local_installation_id",
+}
+CARD_HASH_MEANING_KEYS = {
+    "title",
+    "type",
+    "domain_path",
+    "cross_index",
+    "tags",
+    "trigger_keywords",
+    "if",
+    "action",
+    "predict",
+    "use",
+}
+
+
+def normalize_changed_file(value: str) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    if not text or text.startswith("/") or re.match(r"^[A-Za-z]:", text):
+        return ""
+    parts = PurePosixPath(text).parts
+    if any(part in {"", ".", ".."} for part in parts):
+        return ""
+    return "/".join(parts)
+
+
+def _is_low_risk_path(path: str) -> bool:
+    return path.startswith(LOW_RISK_PREFIXES)
+
+
+def _is_protected_path(path: str) -> bool:
+    return path in PROTECTED_FILES or path.startswith(PROTECTED_PREFIXES)
+
+
+def _iter_yaml_files(root: Path, relative_roots: Iterable[str]) -> Iterable[Path]:
+    for relative in relative_roots:
+        target = root / relative
+        if target.is_file() and target.suffix.lower() in {".yaml", ".yml"}:
+            yield target
+        elif target.is_dir():
+            yield from sorted(target.rglob("*.yaml"))
+            yield from sorted(target.rglob("*.yml"))
+
+
+def _iter_scan_files(root: Path, changed_files: list[str]) -> Iterable[Path]:
+    if changed_files:
+        for relative in changed_files:
+            path = root / relative
+            if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+                yield path
+        return
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+        if ".git" in path.parts:
+            continue
+        yield path
+
+
+def _append_yaml_machine_key_errors(
+    payload: Any,
+    *,
+    path_label: str,
+    errors: list[str],
+    key_path: str = "",
+) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            text_key = str(key)
+            nested_key_path = f"{key_path}.{text_key}" if key_path else text_key
+            if text_key in RAW_MACHINE_KEYS and str(value or "").strip():
+                errors.append(f"{path_label}: raw machine identifier is not allowed at {nested_key_path}")
+            _append_yaml_machine_key_errors(value, path_label=path_label, errors=errors, key_path=nested_key_path)
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload):
+            _append_yaml_machine_key_errors(item, path_label=path_label, errors=errors, key_path=f"{key_path}[{index}]")
+
+
+def _load_yaml_for_check(path: Path, errors: list[str], repo_root: Path) -> dict[str, Any]:
+    try:
+        payload = load_yaml_file(path)
+    except Exception as exc:  # pragma: no cover - parser details vary
+        errors.append(f"{path.relative_to(repo_root).as_posix()}: failed to parse YAML: {exc}")
+        return {}
+    if not isinstance(payload, dict):
+        errors.append(f"{path.relative_to(repo_root).as_posix()}: YAML document must be a mapping")
+        return {}
+    return payload
+
+
+def _has_hash_meaning(payload: dict[str, Any]) -> bool:
+    return any(payload.get(key) for key in CARD_HASH_MEANING_KEYS)
+
+
+def _check_changed_paths(changed_files: list[str], *, enforce_low_risk: bool) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    invalid = [path for path in changed_files if not normalize_changed_file(path)]
+    low_risk = [path for path in changed_files if _is_low_risk_path(path)]
+    protected = [path for path in changed_files if _is_protected_path(path)]
+    outside_low_risk = [path for path in changed_files if not _is_low_risk_path(path)]
+
+    if invalid:
+        errors.extend(f"invalid changed file path: {path}" for path in invalid)
+    if protected:
+        warnings.append("protected organization paths require organization-review evidence and merge rules")
+    if enforce_low_risk and outside_low_risk:
+        errors.extend(f"path is not eligible for low-risk auto-merge: {path}" for path in outside_low_risk)
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "low_risk_files": low_risk,
+        "protected_files": protected,
+        "outside_low_risk_files": outside_low_risk,
+        "all_low_risk": bool(changed_files) and not outside_low_risk,
+    }
+
+
+def _check_sensitive_content(root: Path, changed_files: list[str]) -> dict[str, Any]:
+    errors: list[str] = []
+    scanned: list[str] = []
+    for path in _iter_scan_files(root, changed_files):
+        relative = path.relative_to(root).as_posix()
+        scanned.append(relative)
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for pattern in SECRET_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{relative}: possible secret or credential pattern")
+                break
+        for pattern in LOCAL_PATH_PATTERNS:
+            if pattern.search(text):
+                errors.append(f"{relative}: local machine path is not allowed")
+                break
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            payload = _load_yaml_for_check(path, errors, root)
+            _append_yaml_machine_key_errors(payload, path_label=relative, errors=errors)
+    return {"ok": not errors, "errors": errors, "scanned_files": scanned}
+
+
+def _check_skill_registry(root: Path, registry_relative: str) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    skills_by_id: dict[str, dict[str, Any]] = {}
+    skills_by_bundle_hash: set[tuple[str, str]] = set()
+    registry_path = root / registry_relative
+    if not registry_path.exists():
+        return {"ok": False, "errors": [f"skills registry does not exist: {registry_relative}"], "warnings": []}
+
+    payload = _load_yaml_for_check(registry_path, errors, root)
+    skills = payload.get("skills")
+    if not isinstance(skills, list):
+        return {"ok": False, "errors": errors + ["skills registry must contain a skills list"], "warnings": []}
+
+    for index, item in enumerate(skills):
+        if not isinstance(item, dict):
+            errors.append(f"{registry_relative}: skills[{index}] must be a mapping")
+            continue
+        skill_id = str(item.get("id") or item.get("name") or "").strip()
+        status = str(item.get("status") or "").strip()
+        if not skill_id:
+            errors.append(f"{registry_relative}: skills[{index}] is missing id")
+            continue
+        if skill_id in skills_by_id:
+            warnings.append(f"{registry_relative}: duplicate skill id handle: {skill_id}")
+        skills_by_id[skill_id] = item
+        if status not in SKILL_REVIEW_STATES:
+            errors.append(f"{registry_relative}: skill {skill_id} has invalid status: {status}")
+        if status == "approved":
+            version = str(item.get("version") or item.get("version_time") or "").strip()
+            content_hash = str(item.get("content_hash") or "").strip()
+            if not version:
+                errors.append(f"{registry_relative}: approved skill {skill_id} must pin version")
+            if not content_hash.startswith("sha256:"):
+                errors.append(f"{registry_relative}: approved skill {skill_id} must pin sha256 content_hash")
+        bundle_id = str(item.get("bundle_id") or "").strip()
+        content_hash = str(item.get("content_hash") or "").strip()
+        if bundle_id and content_hash:
+            key = (bundle_id, content_hash)
+            if key in skills_by_bundle_hash:
+                warnings.append(f"{registry_relative}: duplicate Skill bundle version {bundle_id} {content_hash}")
+            skills_by_bundle_hash.add(key)
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "skills_by_id": {skill_id: {"status": str(item.get("status") or "")} for skill_id, item in skills_by_id.items()},
+    }
+
+
+def _check_cards(root: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    hashes: dict[str, list[str]] = {}
+    bundle_count = 0
+
+    for relative_root, expected_statuses in (
+        ("kb/trusted", {"trusted", "approved", "deprecated"}),
+        ("kb/candidates", {"candidate", "rejected", "deprecated"}),
+        ("kb/imports", {"candidate", "rejected", "deprecated"}),
+    ):
+        for path in _iter_yaml_files(root, [relative_root]):
+            relative = path.relative_to(root).as_posix()
+            payload = _load_yaml_for_check(path, errors, root)
+            status = str(payload.get("status") or "").strip()
+            if _has_hash_meaning(payload):
+                hashes.setdefault(card_exchange_hash(payload), []).append(relative)
+            if status and status not in expected_statuses:
+                errors.append(f"{relative}: status {status} is not valid under {relative_root}")
+
+            proposal = payload.get("organization_proposal") if isinstance(payload.get("organization_proposal"), dict) else {}
+            dependencies = proposal.get("skill_dependencies") if isinstance(proposal.get("skill_dependencies"), list) else []
+            if dependencies:
+                bundle_count += 1
+                if not str(proposal.get("source_path") or "").strip():
+                    warnings.append(f"{relative}: card-and-Skill bundle is missing source_path evidence")
+                for index, dependency in enumerate(dependencies):
+                    if not isinstance(dependency, dict):
+                        errors.append(f"{relative}: skill_dependencies[{index}] must be a mapping")
+                        continue
+                    skill_id = str(dependency.get("id") or "").strip()
+                    bundle_id = str(dependency.get("bundle_id") or "").strip()
+                    requirement = str(dependency.get("requirement") or "required").strip()
+                    if not skill_id:
+                        errors.append(f"{relative}: skill_dependencies[{index}] is missing id")
+                    if dependency.get("sharing_mode") == "card-bound-bundle":
+                        if not bundle_id:
+                            errors.append(f"{relative}: skill dependency {skill_id} is missing bundle_id")
+                        if not str(dependency.get("content_hash") or "").strip().startswith("sha256:"):
+                            errors.append(f"{relative}: skill dependency {skill_id} must include sha256 content_hash")
+                        if not str(dependency.get("version_time") or "").strip():
+                            errors.append(f"{relative}: skill dependency {skill_id} must include version_time")
+                        bundle_path = str(dependency.get("bundle_path") or "").strip()
+                        if not bundle_path:
+                            errors.append(f"{relative}: skill dependency {skill_id} must include bundle_path")
+                        else:
+                            normalized_bundle_path = normalize_changed_file(bundle_path)
+                            if not normalized_bundle_path:
+                                errors.append(f"{relative}: skill dependency {skill_id} has invalid bundle_path")
+                            elif not (path.parent / normalized_bundle_path / "SKILL.md").exists():
+                                errors.append(f"{relative}: skill dependency {skill_id} bundle_path does not contain SKILL.md")
+                    if requirement not in SKILL_REQUIREMENTS:
+                        errors.append(f"{relative}: skill dependency {skill_id} has invalid requirement: {requirement}")
+
+    duplicate_hashes = {content_hash: paths for content_hash, paths in hashes.items() if content_hash and len(paths) > 1}
+    for content_hash, paths in duplicate_hashes.items():
+        warnings.append(f"duplicate card content hash {content_hash}: {', '.join(paths)}")
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "duplicate_content_hashes": duplicate_hashes,
+        "bundle_count": bundle_count,
+    }
+
+
+def check_organization_repository(
+    org_root: Path,
+    *,
+    changed_files: Iterable[str] | None = None,
+    enforce_low_risk: bool = False,
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    normalized_changed_files = [
+        normalize_changed_file(path)
+        for path in (changed_files or [])
+        if str(path or "").strip()
+    ]
+    normalized_changed_files = [path for path in normalized_changed_files if path]
+
+    validation = validate_organization_repo(org_root)
+    checks: dict[str, Any] = {
+        "manifest": {
+            "ok": bool(validation.get("ok")),
+            "errors": validation.get("errors") or [],
+        }
+    }
+    errors: list[str] = list(validation.get("errors") or [])
+    warnings: list[str] = []
+    auto_merge_blockers: list[str] = []
+
+    path_policy = _check_changed_paths(normalized_changed_files, enforce_low_risk=enforce_low_risk)
+    checks["path_policy"] = path_policy
+    errors.extend(path_policy["errors"])
+    warnings.extend(path_policy["warnings"])
+    if not path_policy["all_low_risk"]:
+        auto_merge_blockers.append("changed files are not all low-risk paths")
+    if path_policy["protected_files"]:
+        auto_merge_blockers.append("protected path changes require explicit organization review")
+
+    sensitive = _check_sensitive_content(org_root, normalized_changed_files)
+    checks["privacy_scan"] = sensitive
+    errors.extend(sensitive["errors"])
+
+    registry_relative = str(validation.get("skills_registry_path") or "skills/registry.yaml")
+    registry = _check_skill_registry(org_root, registry_relative)
+    checks["skill_registry"] = registry
+    errors.extend(registry["errors"])
+    warnings.extend(registry["warnings"])
+
+    cards = _check_cards(org_root)
+    checks["cards"] = cards
+    errors.extend(cards["errors"])
+    warnings.extend(cards["warnings"])
+    if cards.get("duplicate_content_hashes"):
+        auto_merge_blockers.append("duplicate card content hashes require organization maintenance")
+
+    auto_merge_eligible = bool(normalized_changed_files) and not errors and not auto_merge_blockers
+    if enforce_low_risk and auto_merge_blockers:
+        errors.extend(auto_merge_blockers)
+
+    return {
+        "ok": not errors,
+        "auto_merge_eligible": auto_merge_eligible,
+        "errors": errors,
+        "warnings": warnings,
+        "auto_merge_blockers": auto_merge_blockers,
+        "changed_files": normalized_changed_files,
+        "checks": checks,
+    }

--- a/local_kb/org_cleanup.py
+++ b/local_kb/org_cleanup.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from local_kb.adoption import card_exchange_hash
+from local_kb.common import normalize_text, safe_float, tokenize, utc_now_iso
+from local_kb.org_sources import validate_organization_repo
+from local_kb.store import append_jsonl, load_yaml_file, write_yaml_file
+
+
+ORG_CLEANUP_AUDIT_RELATIVE_PATH = Path("maintenance") / "cleanup_audit.jsonl"
+CARD_ROOTS = ("kb/trusted", "kb/candidates", "kb/imports")
+LOW_RISK_APPLY_ACTIONS = {"confidence-adjust", "status-adjust", "mark-duplicate"}
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _is_skill_sidecar(path: Path, root: Path) -> bool:
+    relative_parts = path.relative_to(root).parts
+    return "skills" in relative_parts
+
+
+def _is_card_payload(payload: dict[str, Any]) -> bool:
+    if not str(payload.get("id") or "").strip():
+        return False
+    return any(payload.get(key) for key in ("title", "if", "action", "predict", "use"))
+
+
+def _iter_org_card_files(org_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for relative_root in CARD_ROOTS:
+        target = org_root / relative_root
+        if not target.exists():
+            continue
+        for path in sorted(target.rglob("*.yaml")):
+            if _is_skill_sidecar(path, org_root):
+                continue
+            payload = load_yaml_file(path)
+            if isinstance(payload, dict) and _is_card_payload(payload):
+                files.append(path)
+    return files
+
+
+def _confidence(payload: dict[str, Any]) -> float:
+    return max(0.0, min(1.0, safe_float(payload.get("confidence"), 0.5)))
+
+
+def _status(payload: dict[str, Any]) -> str:
+    return str(payload.get("status") or "candidate").strip().lower()
+
+
+def _risk_for_path(path: str) -> str:
+    if path.startswith("kb/trusted/"):
+        return "high"
+    if path.startswith("kb/imports/"):
+        return "low"
+    return "medium"
+
+
+def _action_id(action_type: str, target_path: str, reason: str = "") -> str:
+    digest = hashlib.sha256(f"{action_type}|{target_path}|{reason}".encode("utf-8")).hexdigest()[:12]
+    return f"{action_type}-{digest}"
+
+
+def _action(action_type: str, target_path: str, **payload: Any) -> dict[str, Any]:
+    reason = str(payload.get("reason") or "")
+    return {
+        "action_id": _action_id(action_type, target_path, reason),
+        "action_type": action_type,
+        "target_path": target_path,
+        **payload,
+    }
+
+
+def _title_tokens(payload: dict[str, Any]) -> set[str]:
+    return set(tokenize(normalize_text(payload.get("title"))))
+
+
+def _similarity(left: dict[str, Any], right: dict[str, Any]) -> float:
+    left_tokens = _title_tokens(left)
+    right_tokens = _title_tokens(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / max(len(left_tokens), len(right_tokens))
+
+
+def _collect_card_records(org_root: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in _iter_org_card_files(org_root):
+        payload = load_yaml_file(path)
+        relative_path = _relative(path, org_root)
+        records.append(
+            {
+                "path": path,
+                "relative_path": relative_path,
+                "entry_id": str(payload.get("id") or path.stem),
+                "payload": payload,
+                "status": _status(payload),
+                "confidence": _confidence(payload),
+                "content_hash": card_exchange_hash(payload),
+                "risk": _risk_for_path(relative_path),
+            }
+        )
+    return records
+
+
+def _preferred_duplicate_record(records: list[dict[str, Any]]) -> dict[str, Any]:
+    status_rank = {"trusted": 0, "approved": 0, "candidate": 1, "deprecated": 2, "rejected": 3}
+    path_rank = {"kb/trusted/": 0, "kb/candidates/": 1, "kb/imports/": 2}
+
+    def sort_key(record: dict[str, Any]) -> tuple[int, int, float, str]:
+        relative_path = str(record["relative_path"])
+        prefix_rank = next((rank for prefix, rank in path_rank.items() if relative_path.startswith(prefix)), 9)
+        return (
+            status_rank.get(str(record["status"]), 4),
+            prefix_rank,
+            -float(record["confidence"]),
+            relative_path,
+        )
+
+    return sorted(records, key=sort_key)[0]
+
+
+def _skill_version_actions(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_bundle: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        proposal = record["payload"].get("organization_proposal")
+        dependencies = proposal.get("skill_dependencies") if isinstance(proposal, dict) else []
+        if not isinstance(dependencies, list):
+            continue
+        for dependency in dependencies:
+            if not isinstance(dependency, dict):
+                continue
+            bundle_id = str(dependency.get("bundle_id") or "").strip()
+            if not bundle_id:
+                continue
+            by_bundle.setdefault(bundle_id, []).append(
+                {
+                    "record": record,
+                    "dependency": dependency,
+                    "version_time": str(dependency.get("version_time") or ""),
+                    "content_hash": str(dependency.get("content_hash") or ""),
+                }
+            )
+
+    actions: list[dict[str, Any]] = []
+    for bundle_id, versions in by_bundle.items():
+        unique_versions = {(item["version_time"], item["content_hash"]) for item in versions}
+        if len(unique_versions) <= 1:
+            continue
+        latest = sorted(versions, key=lambda item: (item["version_time"], item["content_hash"]))[-1]
+        for item in versions:
+            if item is latest:
+                continue
+            record = item["record"]
+            actions.append(
+                _action(
+                    "skill-version-select",
+                    record["relative_path"],
+                    entry_id=record["entry_id"],
+                    bundle_id=bundle_id,
+                    current_version_time=item["version_time"],
+                    proposed_version_time=latest["version_time"],
+                    current_content_hash=item["content_hash"],
+                    proposed_content_hash=latest["content_hash"],
+                    risk="medium",
+                    apply_supported=False,
+                    reason="A newer card-bound Skill bundle version exists for the same bundle_id.",
+                )
+            )
+    return actions
+
+
+def build_organization_cleanup_proposal(
+    org_root: Path,
+    *,
+    organization_id: str = "",
+    weak_confidence_threshold: float = 0.35,
+    strong_candidate_threshold: float = 0.85,
+    similar_title_threshold: float = 0.75,
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    validation = validate_organization_repo(org_root)
+    if not validation.get("ok"):
+        return {
+            "ok": False,
+            "validation": validation,
+            "organization_id": organization_id,
+            "actions": [],
+            "counts": {},
+        }
+
+    organization_id = organization_id or str(validation.get("organization_id") or "")
+    records = _collect_card_records(org_root)
+    actions: list[dict[str, Any]] = []
+
+    by_hash: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        by_hash.setdefault(record["content_hash"], []).append(record)
+    for content_hash, duplicates in by_hash.items():
+        if len(duplicates) <= 1:
+            continue
+        canonical = _preferred_duplicate_record(duplicates)
+        for duplicate in duplicates:
+            if duplicate is canonical:
+                continue
+            proposed_status = "deprecated" if duplicate["relative_path"].startswith("kb/trusted/") else "rejected"
+            actions.append(
+                _action(
+                    "mark-duplicate",
+                    duplicate["relative_path"],
+                    entry_id=duplicate["entry_id"],
+                    duplicate_of=canonical["relative_path"],
+                    content_hash=content_hash,
+                    current_status=duplicate["status"],
+                    proposed_status=proposed_status,
+                    current_confidence=duplicate["confidence"],
+                    proposed_confidence=min(duplicate["confidence"], 0.25),
+                    risk=duplicate["risk"],
+                    apply_supported=True,
+                    reason="Exact duplicate card content hash exists in the organization repository.",
+                )
+            )
+
+    for record in records:
+        status = record["status"]
+        confidence = record["confidence"]
+        path = record["relative_path"]
+        if status in {"rejected", "deprecated"} and confidence <= 0.2:
+            actions.append(
+                _action(
+                    "delete-card",
+                    path,
+                    entry_id=record["entry_id"],
+                    current_status=status,
+                    current_confidence=confidence,
+                    risk="high",
+                    apply_supported=True,
+                    reason="Low-confidence rejected or deprecated card is eligible for audited deletion.",
+                )
+            )
+            continue
+        if status == "candidate" and confidence <= weak_confidence_threshold:
+            actions.append(
+                _action(
+                    "status-adjust",
+                    path,
+                    entry_id=record["entry_id"],
+                    current_status=status,
+                    proposed_status="rejected",
+                    current_confidence=confidence,
+                    proposed_confidence=min(confidence, 0.25),
+                    risk=record["risk"],
+                    apply_supported=True,
+                    reason="Candidate confidence is below the weak-card threshold.",
+                )
+            )
+        elif status == "candidate" and confidence >= strong_candidate_threshold:
+            actions.append(
+                _action(
+                    "status-adjust",
+                    path,
+                    entry_id=record["entry_id"],
+                    current_status=status,
+                    proposed_status="trusted",
+                    current_confidence=confidence,
+                    proposed_confidence=min(0.95, confidence + 0.03),
+                    risk="medium",
+                    apply_supported=False,
+                    reason="High-confidence candidate should be reviewed for promotion.",
+                )
+            )
+        elif status == "trusted" and confidence < 0.45:
+            proposed_status = "deprecated" if confidence < 0.3 else "trusted"
+            actions.append(
+                _action(
+                    "confidence-adjust" if proposed_status == "trusted" else "status-adjust",
+                    path,
+                    entry_id=record["entry_id"],
+                    current_status=status,
+                    proposed_status=proposed_status,
+                    current_confidence=confidence,
+                    proposed_confidence=max(0.1, round(confidence - 0.1, 2)),
+                    risk="high",
+                    apply_supported=True,
+                    reason="Trusted card has low confidence and needs organization maintenance review.",
+                )
+            )
+
+    for index, left in enumerate(records):
+        for right in records[index + 1 :]:
+            if left["content_hash"] == right["content_hash"]:
+                continue
+            similarity = _similarity(left["payload"], right["payload"])
+            if similarity < similar_title_threshold:
+                continue
+            actions.append(
+                _action(
+                    "merge-cards",
+                    left["relative_path"],
+                    entry_id=left["entry_id"],
+                    related_path=right["relative_path"],
+                    related_entry_id=right["entry_id"],
+                    similarity=round(similarity, 3),
+                    risk="medium",
+                    apply_supported=False,
+                    reason="Card titles are similar enough to require a merge review.",
+                )
+            )
+
+    actions.extend(_skill_version_actions(records))
+    counts: dict[str, int] = {}
+    for action in actions:
+        action_type = str(action.get("action_type") or "")
+        counts[action_type] = counts.get(action_type, 0) + 1
+
+    return {
+        "ok": True,
+        "organization_id": organization_id,
+        "generated_at": utc_now_iso(),
+        "card_count": len(records),
+        "actions": actions,
+        "counts": counts,
+    }
+
+
+def organization_cleanup_audit_path(org_root: Path) -> Path:
+    return Path(org_root) / ORG_CLEANUP_AUDIT_RELATIVE_PATH
+
+
+def _append_audit(org_root: Path, event: dict[str, Any]) -> None:
+    append_jsonl(organization_cleanup_audit_path(org_root), event)
+
+
+def _safe_target_path(org_root: Path, target_path: str) -> Path | None:
+    text = str(target_path or "").strip().replace("\\", "/")
+    if not text or text.startswith("/") or ".." in Path(text).parts:
+        return None
+    target = Path(org_root) / text
+    try:
+        target.resolve().relative_to(Path(org_root).resolve())
+    except ValueError:
+        return None
+    return target
+
+
+def apply_organization_cleanup_proposal(
+    org_root: Path,
+    proposal: dict[str, Any],
+    *,
+    allow_actions: set[str] | None = None,
+    allow_trusted: bool = False,
+    allow_delete: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    allowed = allow_actions or LOW_RISK_APPLY_ACTIONS
+    applied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    errors: list[str] = []
+    now = utc_now_iso()
+
+    for action in proposal.get("actions") or []:
+        if not isinstance(action, dict):
+            continue
+        action_type = str(action.get("action_type") or "").strip()
+        action_id = str(action.get("action_id") or "").strip()
+        target_path = str(action.get("target_path") or "").strip()
+        target = _safe_target_path(org_root, target_path)
+        if action.get("apply_supported") is False:
+            skipped.append({"action_id": action_id, "reason": "proposal action is not implemented for apply", "action_type": action_type})
+            continue
+        if action_type not in allowed:
+            skipped.append({"action_id": action_id, "reason": "action type is not allowed", "action_type": action_type})
+            continue
+        if target is None or not target.exists():
+            skipped.append({"action_id": action_id, "reason": "target path is missing or unsafe", "target_path": target_path})
+            continue
+        if target_path.startswith("kb/trusted/") and not allow_trusted:
+            skipped.append({"action_id": action_id, "reason": "trusted card apply requires allow_trusted", "target_path": target_path})
+            continue
+        if action_type == "delete-card":
+            if not allow_delete:
+                skipped.append({"action_id": action_id, "reason": "delete requires allow_delete", "target_path": target_path})
+                continue
+            if not dry_run:
+                payload = load_yaml_file(target)
+                target.unlink()
+                _append_audit(
+                    org_root,
+                    {
+                        "event_type": "organization-cleanup-applied",
+                        "action_id": action_id,
+                        "action_type": action_type,
+                        "target_path": target_path,
+                        "previous_payload": payload,
+                        "created_at": now,
+                    },
+                )
+            applied.append({"action_id": action_id, "action_type": action_type, "target_path": target_path})
+            continue
+
+        payload = load_yaml_file(target)
+        previous_status = str(payload.get("status") or "")
+        previous_confidence = payload.get("confidence")
+        if "proposed_status" in action:
+            payload["status"] = str(action.get("proposed_status") or previous_status)
+        if "proposed_confidence" in action:
+            payload["confidence"] = max(0.0, min(1.0, safe_float(action.get("proposed_confidence"), _confidence(payload))))
+        cleanup = payload.get("organization_cleanup") if isinstance(payload.get("organization_cleanup"), dict) else {}
+        cleanup.update(
+            {
+                "last_action_id": action_id,
+                "last_action_type": action_type,
+                "last_reason": str(action.get("reason") or ""),
+                "updated_at": now,
+            }
+        )
+        if action.get("duplicate_of"):
+            cleanup["duplicate_of"] = str(action.get("duplicate_of") or "")
+        payload["organization_cleanup"] = cleanup
+        if not dry_run:
+            write_yaml_file(target, payload)
+            _append_audit(
+                org_root,
+                {
+                    "event_type": "organization-cleanup-applied",
+                    "action_id": action_id,
+                    "action_type": action_type,
+                    "target_path": target_path,
+                    "previous_status": previous_status,
+                    "updated_status": payload.get("status"),
+                    "previous_confidence": previous_confidence,
+                    "updated_confidence": payload.get("confidence"),
+                    "created_at": now,
+                },
+            )
+        applied.append({"action_id": action_id, "action_type": action_type, "target_path": target_path})
+
+    return {
+        "ok": not errors,
+        "dry_run": dry_run,
+        "applied_count": len(applied),
+        "skipped_count": len(skipped),
+        "applied": applied,
+        "skipped": skipped,
+        "errors": errors,
+        "audit_path": str(organization_cleanup_audit_path(org_root)),
+    }

--- a/local_kb/org_contribution.py
+++ b/local_kb/org_contribution.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from local_kb.org_sources import _run_git, current_git_commit, utc_timestamp, validate_organization_repo
+
+
+def _safe_segment(value: str) -> str:
+    safe = "".join(char if char.isalnum() or char in "._-" else "-" for char in value.strip()).strip("-")
+    return safe or "contributor"
+
+
+def current_git_branch(repo_path: Path) -> str:
+    result = _run_git(["branch", "--show-current"], cwd=repo_path)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def github_compare_url(remote_url: str, branch: str, *, base_branch: str = "main") -> str:
+    remote = str(remote_url or "").strip()
+    branch = str(branch or "").strip()
+    base_branch = str(base_branch or "main").strip() or "main"
+    if not remote or not branch:
+        return ""
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+    if remote.startswith("git@github.com:"):
+        repo = remote.removeprefix("git@github.com:")
+        remote = f"https://github.com/{repo}"
+    if not remote.startswith("https://github.com/"):
+        return ""
+    return f"{remote}/compare/{quote(base_branch)}...{quote(branch)}?expand=1"
+
+
+def push_organization_branch(
+    org_root: Path,
+    branch_name: str,
+    *,
+    remote: str = "origin",
+    base_branch: str = "main",
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    branch_name = str(branch_name or "").strip() or current_git_branch(org_root)
+    if not branch_name:
+        return {"ok": False, "errors": ["branch_name is required"], "pushed": False, "pull_request_url": ""}
+
+    result = _run_git(["push", "-u", remote, branch_name], cwd=org_root)
+    remote_url_result = _run_git(["remote", "get-url", remote], cwd=org_root)
+    remote_url = remote_url_result.stdout.strip() if remote_url_result.returncode == 0 else ""
+    return {
+        "ok": result.returncode == 0,
+        "errors": [] if result.returncode == 0 else [result.stderr.strip() or result.stdout.strip()],
+        "pushed": result.returncode == 0,
+        "branch": branch_name,
+        "remote": remote,
+        "pull_request_url": github_compare_url(remote_url, branch_name, base_branch=base_branch),
+    }
+
+
+def prepare_organization_import_branch(
+    org_root: Path,
+    outbox_dir: Path,
+    *,
+    contributor_id: str,
+    branch_name: str = "",
+    commit: bool = True,
+    push: bool = False,
+    remote: str = "origin",
+    base_branch: str = "main",
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    outbox_dir = Path(outbox_dir)
+    validation = validate_organization_repo(org_root)
+    if not validation.get("ok"):
+        return {"ok": False, "errors": validation.get("errors") or ["invalid organization repository"], "created_files": []}
+    if not (org_root / ".git").exists():
+        return {"ok": False, "errors": ["organization repository mirror is not a git checkout"], "created_files": []}
+    if not outbox_dir.exists():
+        return {"ok": False, "errors": [f"outbox directory does not exist: {outbox_dir}"], "created_files": []}
+
+    proposal_files = sorted(outbox_dir.glob("*.yaml"))
+    outbox_files = [path for path in sorted(outbox_dir.rglob("*")) if path.is_file()]
+    if not proposal_files:
+        return {"ok": False, "errors": ["outbox directory has no YAML proposals"], "created_files": []}
+
+    safe_contributor = _safe_segment(contributor_id)
+    branch = branch_name or f"contrib/{safe_contributor}/{utc_timestamp().replace(':', '').replace('-', '')}"
+    checkout = _run_git(["checkout", "-B", branch], cwd=org_root)
+    if checkout.returncode != 0:
+        return {"ok": False, "errors": [checkout.stderr.strip() or checkout.stdout.strip()], "created_files": []}
+
+    import_dir = org_root / "kb" / "imports" / safe_contributor
+    import_dir.mkdir(parents=True, exist_ok=True)
+    created_files: list[str] = []
+    for proposal in outbox_files:
+        relative = proposal.relative_to(outbox_dir)
+        target = import_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(proposal, target)
+        created_files.append(target.relative_to(org_root).as_posix())
+
+    add = _run_git(["add", *created_files], cwd=org_root)
+    if add.returncode != 0:
+        return {"ok": False, "errors": [add.stderr.strip() or add.stdout.strip()], "created_files": created_files}
+
+    committed = False
+    commit_hash = ""
+    if commit:
+        result = _run_git(
+            [
+                "-c",
+                "user.name=Khaos Brain",
+                "-c",
+                "user.email=khaos-brain@example.invalid",
+                "commit",
+                "-m",
+                "Add organization KB import proposals",
+            ],
+            cwd=org_root,
+        )
+        if result.returncode != 0:
+            return {"ok": False, "errors": [result.stderr.strip() or result.stdout.strip()], "created_files": created_files}
+        committed = True
+        commit_hash = current_git_commit(org_root)
+
+    push_result = {"pushed": False, "pull_request_url": "", "errors": []}
+    if push:
+        push_result = push_organization_branch(org_root, branch, remote=remote, base_branch=base_branch)
+        if not push_result.get("ok"):
+            return {
+                "ok": False,
+                "errors": push_result.get("errors") or ["failed to push organization contribution branch"],
+                "created_files": created_files,
+                "branch": branch,
+                "committed": committed,
+                "commit": commit_hash,
+                "push": push_result,
+            }
+
+    return {
+        "ok": True,
+        "errors": [],
+        "organization_id": validation.get("organization_id"),
+        "branch": branch,
+        "created_files": created_files,
+        "committed": committed,
+        "commit": commit_hash,
+        "push": push_result,
+        "pull_request_url": push_result.get("pull_request_url") or "",
+    }

--- a/local_kb/org_github_automation.py
+++ b/local_kb/org_github_automation.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from local_kb.org_sources import validate_organization_repo
+
+
+TEMPLATE_ROOT = Path(__file__).resolve().parents[1] / "templates" / "github"
+WORKFLOW_TARGETS = {
+    "org-kb-checks.yml": ".github/workflows/org-kb-checks.yml",
+    "org-kb-auto-merge.yml": ".github/workflows/org-kb-auto-merge.yml",
+    "org_kb_check.py": ".github/scripts/org_kb_check.py",
+}
+
+
+def install_github_automation_templates(
+    org_root: Path,
+    *,
+    template_root: Path | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    org_root = Path(org_root)
+    validation = validate_organization_repo(org_root)
+    if not validation.get("ok"):
+        return {
+            "ok": False,
+            "errors": validation.get("errors") or ["invalid organization repository"],
+            "installed": [],
+            "skipped": [],
+        }
+
+    active_template_root = Path(template_root) if template_root is not None else TEMPLATE_ROOT
+    installed: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []
+
+    for template_name, target_relative in WORKFLOW_TARGETS.items():
+        source = active_template_root / template_name
+        target = org_root / target_relative
+        if not source.exists():
+            errors.append(f"missing GitHub automation template: {source}")
+            continue
+        if target.exists() and not overwrite:
+            skipped.append(target_relative)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        installed.append(target_relative)
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "installed": installed,
+        "skipped": skipped,
+        "organization_id": validation.get("organization_id"),
+    }

--- a/local_kb/org_maintenance.py
+++ b/local_kb/org_maintenance.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from local_kb.org_checks import check_organization_repository
+from local_kb.org_cleanup import build_organization_cleanup_proposal
+from local_kb.org_outbox import organization_outbox_dir
+from local_kb.org_sources import validate_organization_repo
+from local_kb.skill_sharing import find_local_skill_metadata
+from local_kb.store import load_organization_entries
+
+
+ORGANIZATION_REVIEW_SKILL_ID = "organization-review"
+
+
+def build_organization_maintenance_report(
+    org_root: Path,
+    *,
+    repo_root: Path | None = None,
+    organization_id: str = "",
+) -> dict[str, Any]:
+    validation = validate_organization_repo(org_root)
+    if not validation.get("ok"):
+        return {
+            "ok": False,
+            "validation": validation,
+            "entry_count": 0,
+            "outbox_count": 0,
+            "recommendations": ["fix-organization-repository-validation"],
+        }
+
+    organization_id = organization_id or str(validation.get("organization_id") or "")
+    entries = load_organization_entries(
+        Path(org_root),
+        organization_id,
+        source_commit=str(validation.get("commit") or ""),
+    )
+    organization_check = check_organization_repository(org_root)
+    duplicate_content_hashes = (
+        organization_check.get("checks", {})
+        .get("cards", {})
+        .get("duplicate_content_hashes", {})
+    )
+    if not isinstance(duplicate_content_hashes, dict):
+        duplicate_content_hashes = {}
+
+    outbox_count = 0
+    review_skill: dict[str, Any] = {
+        "id": ORGANIZATION_REVIEW_SKILL_ID,
+        "installed": False,
+        "status": "missing",
+    }
+    if repo_root is not None:
+        outbox_dir = organization_outbox_dir(Path(repo_root), organization_id)
+        outbox_count = len(list(outbox_dir.glob("*.yaml"))) if outbox_dir.exists() else 0
+        skill_metadata = find_local_skill_metadata(Path(repo_root), ORGANIZATION_REVIEW_SKILL_ID)
+        if skill_metadata is not None:
+            review_skill = {
+                **skill_metadata,
+                "installed": True,
+            }
+
+    recommendations: list[str] = []
+    if validation.get("candidate_count", 0):
+        recommendations.append("review-organization-candidates")
+    if outbox_count:
+        recommendations.append("review-local-outbox-proposals")
+    if validation.get("skill_count", 0):
+        recommendations.append("review-skill-registry")
+    if duplicate_content_hashes:
+        recommendations.append("review-duplicate-card-content-hashes")
+    if organization_check.get("errors"):
+        recommendations.append("fix-organization-check-errors")
+    if not review_skill["installed"]:
+        recommendations.append("install-organization-review-skill-before-full-maintenance")
+    cleanup_proposal = build_organization_cleanup_proposal(org_root, organization_id=organization_id)
+    cleanup_actions = cleanup_proposal.get("actions") if isinstance(cleanup_proposal.get("actions"), list) else []
+    if cleanup_actions:
+        recommendations.append("review-organization-cleanup-proposals")
+
+    return {
+        "ok": True,
+        "validation": validation,
+        "organization_check": {
+            "ok": bool(organization_check.get("ok")),
+            "error_count": len(organization_check.get("errors") or []),
+            "warning_count": len(organization_check.get("warnings") or []),
+            "auto_merge_eligible": bool(organization_check.get("auto_merge_eligible")),
+            "auto_merge_blockers": organization_check.get("auto_merge_blockers") or [],
+        },
+        "cleanup": {
+            "duplicate_content_hash_count": len(duplicate_content_hashes),
+            "duplicate_content_hashes": duplicate_content_hashes,
+            "proposal_action_count": len(cleanup_actions),
+            "proposal_counts": cleanup_proposal.get("counts") or {},
+            "similar_card_merge_apply": "planned",
+            "weak_card_rejection_apply": "planned",
+            "candidate_delete_apply": "planned",
+            "skill_bundle_cleanup_apply": "partial",
+        },
+        "organization_id": organization_id,
+        "entry_count": len(entries),
+        "trusted_count": validation.get("trusted_count", 0),
+        "candidate_count": validation.get("candidate_count", 0),
+        "skill_count": validation.get("skill_count", 0),
+        "outbox_count": outbox_count,
+        "organization_review_skill": review_skill,
+        "recommendations": recommendations,
+    }

--- a/local_kb/org_outbox.py
+++ b/local_kb/org_outbox.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+from typing import Any
+
+from local_kb.adoption import ADOPTION_KEY, adoption_state, card_exchange_hash, record_exchange_hash, recorded_exchange_hashes
+from local_kb.org_sources import utc_timestamp
+from local_kb.skill_sharing import build_card_skill_dependency_manifest, materialize_skill_bundle_dependencies
+from local_kb.store import load_entries, load_organization_entries, write_yaml_file
+
+
+SHAREABLE_CARD_TYPES = {"model", "heuristic"}
+SHAREABLE_SCOPES = {"public"}
+
+
+def organization_outbox_dir(repo_root: Path, organization_id: str) -> Path:
+    safe_id = "".join(char if char.isalnum() or char in "._-" else "-" for char in organization_id).strip("-")
+    return repo_root / "kb" / "outbox" / "organization" / (safe_id or "org")
+
+
+def _safe_file_stem(value: Any) -> str:
+    text = str(value or "").strip()
+    safe = "".join(char if char.isalnum() or char in "._-" else "-" for char in text).strip("-")
+    return safe or "card"
+
+
+def _organization_exchange_hashes(
+    organization_sources: list[dict[str, Any]] | None,
+    *,
+    organization_id: str,
+) -> set[str]:
+    hashes: set[str] = set()
+    for source in organization_sources or []:
+        source_org_id = str(source.get("organization_id") or source.get("id") or "").strip()
+        if organization_id and source_org_id and source_org_id != organization_id:
+            continue
+        org_root = Path(str(source.get("path") or source.get("local_path") or ""))
+        if not org_root.exists():
+            continue
+        for entry in load_organization_entries(
+            org_root,
+            source_org_id or organization_id,
+            source_repo=str(source.get("source_repo") or source.get("repo_url") or ""),
+            source_commit=str(source.get("source_commit") or ""),
+            scopes=("trusted", "candidates", "imports"),
+        ):
+            hashes.add(card_exchange_hash(entry.data))
+    return hashes
+
+
+def share_eligibility(entry_data: dict[str, Any]) -> dict[str, Any]:
+    card_type = str(entry_data.get("type") or "").strip().lower()
+    card_scope = str(entry_data.get("scope") or "").strip().lower()
+    reasons: list[str] = []
+    if card_type not in SHAREABLE_CARD_TYPES:
+        reasons.append("card type is not shareable")
+    if card_scope not in SHAREABLE_SCOPES:
+        reasons.append("card scope is not public")
+
+    adoption = entry_data.get(ADOPTION_KEY) if isinstance(entry_data.get(ADOPTION_KEY), dict) else {}
+    adoption_status = ""
+    if adoption:
+        adoption_status = adoption_state(entry_data)
+        if adoption_status == "clean":
+            reasons.append("clean adopted organization card does not need feedback")
+        if adoption_status == "locally_rejected":
+            reasons.append("locally rejected adopted card is not shared automatically")
+
+    return {
+        "eligible": not reasons,
+        "reasons": reasons,
+        "adoption_state": adoption_status,
+    }
+
+
+def build_organization_proposal_payload(
+    entry_data: dict[str, Any],
+    *,
+    organization_id: str,
+    source_path: str,
+    created_at: str,
+) -> dict[str, Any]:
+    payload = copy.deepcopy(entry_data)
+    adoption = payload.pop(ADOPTION_KEY, None)
+    original_status = str(payload.get("status") or "").strip()
+    payload["status"] = "candidate"
+    payload["organization_proposal"] = {
+        "organization_id": organization_id,
+        "source_path": source_path,
+        "created_at": created_at,
+        "content_hash": card_exchange_hash(entry_data),
+        "proposal_kind": "adopted-feedback" if isinstance(adoption, dict) else "new-card",
+        "adoption_state": adoption_state(entry_data) if isinstance(adoption, dict) else "",
+        "source_entry_id": str((adoption or {}).get("source_entry_id") or entry_data.get("id") or "").strip()
+        if isinstance(adoption, dict)
+        else str(entry_data.get("id") or "").strip(),
+        "source_commit": str((adoption or {}).get("source_commit") or "").strip() if isinstance(adoption, dict) else "",
+        "source_repo": str((adoption or {}).get("source_repo") or "").strip() if isinstance(adoption, dict) else "",
+        "original_status": original_status,
+    }
+    return payload
+
+
+def build_organization_outbox(
+    repo_root: Path,
+    *,
+    organization_id: str,
+    dry_run: bool = False,
+    organization_sources: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(repo_root)
+    organization_id = str(organization_id or "").strip()
+    if not organization_id:
+        return {"ok": False, "errors": ["organization_id is required"], "created": [], "skipped": []}
+
+    outbox_dir = organization_outbox_dir(repo_root, organization_id)
+    created: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    now = utc_timestamp()
+    exported_hashes: set[str] = set()
+    prior_export_hashes = recorded_exchange_hashes(repo_root, {"exported", "uploaded"})
+    organization_hashes = _organization_exchange_hashes(organization_sources, organization_id=organization_id)
+
+    for entry in load_entries(repo_root):
+        entry_id = str(entry.data.get("id") or entry.path.stem).strip()
+        eligibility = share_eligibility(entry.data)
+        source_path = os.path.relpath(entry.path, repo_root)
+        if not eligibility["eligible"]:
+            skipped.append({"entry_id": entry_id, "path": source_path, "reasons": eligibility["reasons"]})
+            continue
+        content_hash = card_exchange_hash(entry.data)
+        if content_hash in prior_export_hashes:
+            skipped.append({"entry_id": entry_id, "path": source_path, "reasons": ["content hash was already exported from this installation"]})
+            continue
+        if content_hash in organization_hashes:
+            skipped.append({"entry_id": entry_id, "path": source_path, "reasons": ["content hash already exists in organization repository"]})
+            continue
+        if content_hash in exported_hashes:
+            skipped.append({"entry_id": entry_id, "path": source_path, "reasons": ["duplicate content hash already exported"]})
+            continue
+
+        payload = build_organization_proposal_payload(
+            entry.data,
+            organization_id=organization_id,
+            source_path=source_path,
+            created_at=now,
+        )
+        skill_dependencies = build_card_skill_dependency_manifest(
+            repo_root,
+            entry.data,
+            persist_bundle_metadata=not dry_run,
+        )
+        if skill_dependencies:
+            payload["organization_proposal"]["skill_dependencies"] = materialize_skill_bundle_dependencies(
+                skill_dependencies,
+                outbox_dir,
+                dry_run=dry_run,
+            )
+        target_path = outbox_dir / f"{_safe_file_stem(entry_id)}.yaml"
+        if not dry_run:
+            write_yaml_file(target_path, payload)
+        created.append(
+            {
+                "entry_id": entry_id,
+                "path": str(target_path),
+                "source_path": source_path,
+                "content_hash": content_hash,
+                "proposal_kind": payload["organization_proposal"]["proposal_kind"],
+            }
+        )
+        exported_hashes.add(content_hash)
+        if not dry_run:
+            record_exchange_hash(
+                repo_root,
+                content_hash,
+                direction="exported",
+                organization_id=organization_id,
+                source_path=source_path,
+                local_path=str(target_path),
+                entry_id=entry_id,
+            )
+
+    return {
+        "ok": True,
+        "organization_id": organization_id,
+        "outbox_dir": str(outbox_dir),
+        "dry_run": dry_run,
+        "organization_hash_count": len(organization_hashes),
+        "created_count": len(created),
+        "skipped_count": len(skipped),
+        "created": created,
+        "skipped": skipped,
+    }

--- a/local_kb/org_sources.py
+++ b/local_kb/org_sources.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from local_kb.store import load_yaml_file
+
+
+ORG_KB_MANIFEST = "khaos_org_kb.yaml"
+ORG_KB_KIND = "khaos-organization-kb"
+SUPPORTED_SCHEMA_VERSION = 1
+
+
+def utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _as_relative_path(value: Any) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    if not text or text.startswith("/") or re.match(r"^[A-Za-z]:", text):
+        return ""
+    parts = [part for part in text.split("/") if part not in {"", "."}]
+    if any(part == ".." for part in parts):
+        return ""
+    return "/".join(parts)
+
+
+def _git_executable() -> str:
+    discovered = shutil.which("git") or shutil.which("git.cmd")
+    if discovered:
+        return discovered
+    bundled = Path.home() / "AppData" / "Local" / "OpenAI" / "Codex" / "bin" / "git.cmd"
+    if bundled.exists():
+        return str(bundled)
+    return "git"
+
+
+def _run_git(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [_git_executable(), *args],
+            cwd=str(cwd) if cwd is not None else None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(args=[_git_executable(), *args], returncode=127, stdout="", stderr=str(exc))
+
+
+def current_git_commit(repo_path: Path) -> str:
+    result = _run_git(["rev-parse", "HEAD"], cwd=repo_path)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def default_org_mirror_path(repo_root: Path, organization_id: str) -> Path:
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", organization_id.strip()).strip("-")
+    if not safe_id:
+        safe_id = "org"
+    return repo_root / ".local" / "organization_sources" / safe_id
+
+
+def guess_organization_source_id(repo_url: str) -> str:
+    text = str(repo_url or "").strip().replace("\\", "/")
+    if not text:
+        return "org"
+    text = text.rstrip("/")
+    if text.endswith(".git"):
+        text = text[:-4]
+    candidate = text.rsplit("/", 1)[-1].strip()
+    if ":" in candidate:
+        candidate = candidate.rsplit(":", 1)[-1]
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", candidate).strip("-") or "org"
+
+
+def clone_or_fetch_organization_repo(repo_url: str, local_path: Path) -> dict[str, Any]:
+    repo_url = str(repo_url or "").strip()
+    if not repo_url:
+        return {"ok": False, "action": "none", "errors": ["missing repository URL"], "commit": ""}
+
+    local_path = Path(local_path)
+    if (local_path / ".git").exists():
+        result = _run_git(["fetch", "--prune"], cwd=local_path)
+        if result.returncode != 0:
+            return {
+                "ok": False,
+                "action": "fetch",
+                "errors": [result.stderr.strip() or result.stdout.strip()],
+                "commit": current_git_commit(local_path),
+            }
+        update = _run_git(["pull", "--ff-only"], cwd=local_path)
+        return {
+            "ok": update.returncode == 0,
+            "action": "fetch",
+            "errors": [] if update.returncode == 0 else [update.stderr.strip() or update.stdout.strip()],
+            "commit": current_git_commit(local_path),
+        }
+
+    if local_path.exists() and any(local_path.iterdir()):
+        return {
+            "ok": False,
+            "action": "none",
+            "errors": [f"local mirror path is not an empty directory: {local_path}"],
+            "commit": "",
+        }
+
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    result = _run_git(["clone", repo_url, str(local_path)])
+    return {
+        "ok": result.returncode == 0,
+        "action": "clone",
+        "errors": [] if result.returncode == 0 else [result.stderr.strip() or result.stdout.strip()],
+        "commit": current_git_commit(local_path) if result.returncode == 0 else "",
+    }
+
+
+def connect_organization_source(
+    repo_root: Path,
+    repo_url: str,
+    *,
+    local_mirror_path: str | Path | None = None,
+) -> dict[str, Any]:
+    repo_url = str(repo_url or "").strip()
+    now = utc_timestamp()
+    if local_mirror_path:
+        mirror_path = Path(local_mirror_path)
+    else:
+        mirror_path = default_org_mirror_path(Path(repo_root), guess_organization_source_id(repo_url))
+
+    if not repo_url:
+        settings = {
+            "repo_url": "",
+            "local_mirror_path": str(mirror_path),
+            "organization_id": "",
+            "validated": False,
+            "validation_status": "not_configured",
+            "validation_message": "Organization repository URL is required.",
+            "last_validated_at": now,
+            "last_sync_commit": "",
+            "last_sync_at": "",
+        }
+        return {"ok": False, "settings": settings, "clone": {}, "validation": {}}
+
+    clone_result = clone_or_fetch_organization_repo(repo_url, mirror_path)
+    if not clone_result.get("ok"):
+        settings = {
+            "repo_url": repo_url,
+            "local_mirror_path": str(mirror_path),
+            "organization_id": "",
+            "validated": False,
+            "validation_status": "invalid",
+            "validation_message": "; ".join(clone_result.get("errors") or ["Failed to clone or fetch organization repository."]),
+            "last_validated_at": now,
+            "last_sync_commit": "",
+            "last_sync_at": "",
+        }
+        return {"ok": False, "settings": settings, "clone": clone_result, "validation": {}}
+
+    validation = validate_organization_repo(mirror_path)
+    validation_ok = bool(validation.get("ok"))
+    errors = validation.get("errors") or []
+    commit = str(validation.get("commit") or clone_result.get("commit") or "")
+    settings = {
+        "repo_url": repo_url,
+        "local_mirror_path": str(mirror_path),
+        "organization_id": str(validation.get("organization_id") or ""),
+        "validated": validation_ok,
+        "validation_status": "valid" if validation_ok else "invalid",
+        "validation_message": "Organization KB repository is valid." if validation_ok else "; ".join(errors),
+        "last_validated_at": now,
+        "last_sync_commit": commit if validation_ok else "",
+        "last_sync_at": now if validation_ok else "",
+    }
+    return {"ok": validation_ok, "settings": settings, "clone": clone_result, "validation": validation}
+
+
+def validate_organization_repo(repo_path: Path) -> dict[str, Any]:
+    repo_path = Path(repo_path)
+    errors: list[str] = []
+    manifest_path = repo_path / ORG_KB_MANIFEST
+
+    if not repo_path.exists() or not repo_path.is_dir():
+        return {
+            "ok": False,
+            "errors": [f"repository path does not exist: {repo_path}"],
+            "repo_path": str(repo_path),
+        }
+
+    if not manifest_path.exists():
+        return {
+            "ok": False,
+            "errors": [f"missing organization KB manifest: {ORG_KB_MANIFEST}"],
+            "repo_path": str(repo_path),
+        }
+
+    try:
+        manifest = load_yaml_file(manifest_path)
+    except Exception as exc:  # pragma: no cover - defensive around malformed YAML parser errors
+        return {
+            "ok": False,
+            "errors": [f"failed to read organization KB manifest: {exc}"],
+            "repo_path": str(repo_path),
+        }
+
+    if not isinstance(manifest, dict):
+        manifest = {}
+        errors.append("manifest must be a mapping")
+
+    if manifest.get("kind") != ORG_KB_KIND:
+        errors.append(f"manifest kind must be {ORG_KB_KIND}")
+
+    if manifest.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SUPPORTED_SCHEMA_VERSION}")
+
+    organization_id = str(manifest.get("organization_id") or "").strip()
+    if not organization_id:
+        errors.append("organization_id is required")
+
+    kb = manifest.get("kb") if isinstance(manifest.get("kb"), dict) else {}
+    skills = manifest.get("skills") if isinstance(manifest.get("skills"), dict) else {}
+
+    trusted_path_text = _as_relative_path(kb.get("trusted_path") or "kb/trusted")
+    candidates_path_text = _as_relative_path(kb.get("candidates_path") or "kb/candidates")
+    imports_path_text = _as_relative_path(kb.get("imports_path") or "kb/imports")
+    registry_path_text = _as_relative_path(skills.get("registry_path") or "skills/registry.yaml")
+    skill_candidates_path_text = _as_relative_path(skills.get("candidates_path") or "skills/candidates")
+
+    required_dirs = {
+        "trusted_path": trusted_path_text,
+        "candidates_path": candidates_path_text,
+    }
+    for label, relative in required_dirs.items():
+        if not relative:
+            errors.append(f"{label} must be a relative path")
+            continue
+        if not (repo_path / relative).is_dir():
+            errors.append(f"{label} does not exist or is not a directory: {relative}")
+
+    optional_dirs = {
+        "imports_path": imports_path_text,
+        "skill_candidates_path": skill_candidates_path_text,
+    }
+    for label, relative in optional_dirs.items():
+        if relative and not (repo_path / relative).exists():
+            errors.append(f"{label} does not exist: {relative}")
+
+    registry_skills: list[Any] = []
+    if registry_path_text:
+        registry_path = repo_path / registry_path_text
+        if registry_path.exists():
+            registry_payload = load_yaml_file(registry_path)
+            if isinstance(registry_payload, dict) and isinstance(registry_payload.get("skills"), list):
+                registry_skills = registry_payload["skills"]
+            else:
+                errors.append("skills registry must contain a skills list")
+        else:
+            errors.append(f"skills registry does not exist: {registry_path_text}")
+
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "repo_path": str(repo_path),
+        "manifest_path": str(manifest_path),
+        "organization_id": organization_id,
+        "schema_version": manifest.get("schema_version"),
+        "trusted_path": trusted_path_text,
+        "candidates_path": candidates_path_text,
+        "imports_path": imports_path_text,
+        "skills_registry_path": registry_path_text,
+        "skill_candidates_path": skill_candidates_path_text,
+        "trusted_count": len(list((repo_path / trusted_path_text).rglob("*.yaml"))) if trusted_path_text else 0,
+        "candidate_count": len(list((repo_path / candidates_path_text).rglob("*.yaml"))) if candidates_path_text else 0,
+        "skill_count": len(registry_skills),
+        "commit": current_git_commit(repo_path),
+    }

--- a/local_kb/search.py
+++ b/local_kb/search.py
@@ -11,8 +11,14 @@ from local_kb.common import (
     safe_float,
     tokenize,
 )
+from local_kb.adoption import (
+    blocked_organization_download_hashes,
+    card_exchange_hash,
+    dedupe_local_entries_by_exchange_hash,
+)
 from local_kb.models import Entry
-from local_kb.store import load_entries
+from local_kb.source_labels import card_source_summary
+from local_kb.store import load_entries, load_organization_entries
 
 
 def longest_common_prefix(left: list[str], right: list[str]) -> int:
@@ -81,6 +87,8 @@ def score_entry(entry: Entry, query_tokens: list[str], path_hint_segments: list[
         return 0.0
 
     score = relevance_score + confidence * 2.0
+    if status == "rejected":
+        return 0.0
     if status == "trusted":
         score += 4.0
     if status == "deprecated":
@@ -88,14 +96,61 @@ def score_entry(entry: Entry, query_tokens: list[str], path_hint_segments: list[
     return score
 
 
-def search_entries(repo_root: Path, query: str, path_hint: str = "", top_k: int = 5) -> list[Entry]:
+def search_loaded_entries(entries: list[Entry], query: str, path_hint: str = "", top_k: int = 5) -> list[Entry]:
     query_tokens = tokenize(query)
     path_hint_segments = parse_route_segments(path_hint)
-    entries = load_entries(repo_root)
     for entry in entries:
         entry.score = score_entry(entry, query_tokens, path_hint_segments)
     ranked = [entry for entry in sorted(entries, key=lambda item: item.score, reverse=True) if entry.score > 0]
     return ranked[:top_k]
+
+
+def search_entries(repo_root: Path, query: str, path_hint: str = "", top_k: int = 5) -> list[Entry]:
+    return search_loaded_entries(
+        dedupe_local_entries_by_exchange_hash(load_entries(repo_root)),
+        query=query,
+        path_hint=path_hint,
+        top_k=top_k,
+    )
+
+
+def search_multi_source_entries(
+    repo_root: Path,
+    query: str,
+    path_hint: str = "",
+    top_k: int = 5,
+    organization_sources: list[dict[str, Any]] | None = None,
+) -> list[Entry]:
+    local_entries = dedupe_local_entries_by_exchange_hash(load_entries(repo_root))
+    local_results = search_loaded_entries(local_entries, query=query, path_hint=path_hint, top_k=top_k)
+    blocked_hashes = blocked_organization_download_hashes(repo_root) if organization_sources else set()
+    organization_results: list[Entry] = []
+    for source in organization_sources or []:
+        org_root = Path(str(source.get("path") or source.get("local_path") or ""))
+        organization_id = str(source.get("organization_id") or source.get("id") or "").strip()
+        if not org_root.exists() or not organization_id:
+            continue
+        entries = load_organization_entries(
+            org_root,
+            organization_id,
+            source_repo=str(source.get("source_repo") or source.get("repo_url") or ""),
+            source_commit=str(source.get("source_commit") or ""),
+        )
+        for entry in search_loaded_entries(entries, query=query, path_hint=path_hint, top_k=top_k):
+            if card_exchange_hash(entry.data) in blocked_hashes:
+                continue
+            organization_results.append(entry)
+    return [*local_results, *organization_results][:top_k]
+
+
+def _display_path(entry: Entry, repo_root: Path) -> str:
+    source_path = str(entry.source.get("path") or "").strip()
+    if source_path and entry.source.get("kind") == "organization":
+        return source_path
+    try:
+        return os.path.relpath(entry.path, repo_root)
+    except ValueError:
+        return str(entry.path)
 
 
 def render_entry(entry: Entry, repo_root: Path) -> dict[str, Any]:
@@ -114,7 +169,9 @@ def render_entry(entry: Entry, repo_root: Path) -> dict[str, Any]:
         "trigger_keywords": data.get("trigger_keywords", []),
         "predicted_result": get_predicted_result(data),
         "guidance": get_guidance(data),
-        "path": os.path.relpath(entry.path, repo_root),
+        "path": _display_path(entry, repo_root),
+        "source_info": entry.source,
+        **card_source_summary(data, entry.source),
         "score": round(entry.score, 3),
     }
 

--- a/local_kb/settings.py
+++ b/local_kb/settings.py
@@ -1,14 +1,40 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 from local_kb.i18n import DEFAULT_LANGUAGE, normalize_language
 
 
+PERSONAL_MODE = "personal"
+ORGANIZATION_MODE = "organization"
+VALID_DESKTOP_MODES = {PERSONAL_MODE, ORGANIZATION_MODE}
+VALID_ORG_VALIDATION_STATUSES = {"not_configured", "pending", "valid", "invalid"}
+
 DEFAULT_DESKTOP_SETTINGS = {
     "language": DEFAULT_LANGUAGE,
+    "mode": PERSONAL_MODE,
+    "organization": {
+        "repo_url": "",
+        "local_mirror_path": "",
+        "organization_id": "",
+        "validated": False,
+        "validation_status": "not_configured",
+        "validation_message": "",
+        "last_validated_at": "",
+        "last_sync_commit": "",
+        "last_sync_at": "",
+        "organization_maintenance_requested": False,
+        "organization_maintenance_validated": False,
+        "organization_maintenance_status": "not_configured",
+        "organization_maintenance_message": "",
+        "maintainer_mode_requested": False,
+        "maintainer_validated": False,
+        "maintainer_validation_status": "not_configured",
+        "maintainer_validation_message": "",
+    },
 }
 
 
@@ -16,25 +42,131 @@ def desktop_settings_path(repo_root: Path) -> Path:
     return repo_root / ".local" / "khaos_brain_desktop_settings.json"
 
 
+def normalize_desktop_mode(value: Any) -> str:
+    mode = str(value or "").strip().lower()
+    if mode in VALID_DESKTOP_MODES:
+        return mode
+    return PERSONAL_MODE
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_validation_status(value: Any) -> str:
+    status = str(value or "").strip().lower()
+    if status in VALID_ORG_VALIDATION_STATUSES:
+        return status
+    return "not_configured"
+
+
+def _normalize_organization_settings(value: Any) -> dict[str, Any]:
+    payload = value if isinstance(value, dict) else {}
+    validation_status = _normalize_validation_status(payload.get("validation_status"))
+    validated = bool(payload.get("validated")) and validation_status == "valid"
+    if validated:
+        validation_status = "valid"
+    maintainer_validation_status = _normalize_validation_status(payload.get("maintainer_validation_status"))
+    maintainer_validated = bool(payload.get("maintainer_validated")) and validated and maintainer_validation_status == "valid"
+    maintenance_requested = bool(payload.get("organization_maintenance_requested", payload.get("maintainer_mode_requested")))
+    maintenance_status = _normalize_validation_status(payload.get("organization_maintenance_status", payload.get("maintainer_validation_status")))
+    maintenance_validated = maintenance_requested and validated
+    if maintenance_validated:
+        maintenance_status = "valid"
+
+    return {
+        "repo_url": _normalize_text(payload.get("repo_url")),
+        "local_mirror_path": _normalize_text(payload.get("local_mirror_path")),
+        "organization_id": _normalize_text(payload.get("organization_id")),
+        "validated": validated,
+        "validation_status": validation_status,
+        "validation_message": _normalize_text(payload.get("validation_message")),
+        "last_validated_at": _normalize_text(payload.get("last_validated_at")),
+        "last_sync_commit": _normalize_text(payload.get("last_sync_commit")),
+        "last_sync_at": _normalize_text(payload.get("last_sync_at")),
+        "organization_maintenance_requested": maintenance_requested,
+        "organization_maintenance_validated": maintenance_validated,
+        "organization_maintenance_status": maintenance_status,
+        "organization_maintenance_message": _normalize_text(
+            payload.get("organization_maintenance_message", payload.get("maintainer_validation_message"))
+        ),
+        "maintainer_mode_requested": maintenance_requested,
+        "maintainer_validated": maintainer_validated,
+        "maintainer_validation_status": "valid" if maintainer_validated else maintainer_validation_status,
+        "maintainer_validation_message": _normalize_text(payload.get("maintainer_validation_message")),
+    }
+
+
 def load_desktop_settings(repo_root: Path) -> dict[str, Any]:
     path = desktop_settings_path(repo_root)
     if not path.exists():
-        return dict(DEFAULT_DESKTOP_SETTINGS)
+        return deepcopy(DEFAULT_DESKTOP_SETTINGS)
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
-        return dict(DEFAULT_DESKTOP_SETTINGS)
+        return deepcopy(DEFAULT_DESKTOP_SETTINGS)
     if not isinstance(payload, dict):
-        return dict(DEFAULT_DESKTOP_SETTINGS)
-    settings = dict(DEFAULT_DESKTOP_SETTINGS)
+        return deepcopy(DEFAULT_DESKTOP_SETTINGS)
+    settings = deepcopy(DEFAULT_DESKTOP_SETTINGS)
     settings["language"] = normalize_language(payload.get("language"))
+    settings["mode"] = normalize_desktop_mode(payload.get("mode"))
+    settings["organization"] = _normalize_organization_settings(payload.get("organization"))
+    if settings["mode"] == ORGANIZATION_MODE and not settings["organization"]["validated"]:
+        settings["mode"] = PERSONAL_MODE
     return settings
 
 
 def save_desktop_settings(repo_root: Path, settings: dict[str, Any]) -> Path:
-    payload = dict(DEFAULT_DESKTOP_SETTINGS)
+    payload = deepcopy(DEFAULT_DESKTOP_SETTINGS)
     payload["language"] = normalize_language(settings.get("language"))
+    payload["mode"] = normalize_desktop_mode(settings.get("mode"))
+    payload["organization"] = _normalize_organization_settings(settings.get("organization"))
+    if payload["mode"] == ORGANIZATION_MODE and not payload["organization"]["validated"]:
+        payload["mode"] = PERSONAL_MODE
     path = desktop_settings_path(repo_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def organization_sources_from_settings(settings: dict[str, Any]) -> list[dict[str, Any]]:
+    if normalize_desktop_mode(settings.get("mode")) != ORGANIZATION_MODE:
+        return []
+    organization = _normalize_organization_settings(settings.get("organization"))
+    if not organization["validated"] or organization["validation_status"] != "valid":
+        return []
+    if not organization["local_mirror_path"] or not organization["organization_id"]:
+        return []
+    return [
+        {
+            "path": organization["local_mirror_path"],
+            "organization_id": organization["organization_id"],
+            "repo_url": organization["repo_url"],
+            "source_commit": organization["last_sync_commit"],
+        }
+    ]
+
+
+def maintainer_status_from_settings(settings: dict[str, Any]) -> dict[str, Any]:
+    return maintenance_participation_status_from_settings(settings)
+
+
+def maintenance_participation_status_from_settings(settings: dict[str, Any]) -> dict[str, Any]:
+    organization = _normalize_organization_settings(settings.get("organization"))
+    source_ready = normalize_desktop_mode(settings.get("mode")) == ORGANIZATION_MODE and organization["validated"]
+    requested = bool(organization.get("organization_maintenance_requested"))
+    available = requested and source_ready
+    if available:
+        reason = "organization maintenance participation is enabled"
+    elif not source_ready:
+        reason = "organization mode is not connected to a validated repository"
+    elif not requested:
+        reason = "organization maintenance participation is not requested"
+    else:
+        reason = organization.get("organization_maintenance_message") or "organization maintenance participation is not available"
+    return {
+        "requested": requested,
+        "available": available,
+        "validation_status": organization.get("organization_maintenance_status"),
+        "reason": reason,
+    }

--- a/local_kb/skill_sharing.py
+++ b/local_kb/skill_sharing.py
@@ -1,0 +1,852 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from local_kb.card_ids import installation_short_label, new_card_id
+from local_kb.common import utc_now_iso
+from local_kb.store import write_yaml_file
+from local_kb.store import yaml
+
+
+SKILL_REVIEW_STATES = {"candidate", "approved", "rejected"}
+LOCAL_SKILL_BUNDLE_STATE_ROOT = Path(".local") / "skill_bundles" / "local"
+IMPORTED_SKILL_BUNDLE_ROOT = Path(".local") / "organization_skills"
+SKILL_BUNDLE_UPDATE_POLICY = "original_author_only"
+DEPENDENCY_PASSTHROUGH_KEYS = {
+    "bundle_id",
+    "bundle_path",
+    "bundle_metadata_path",
+    "content_hash",
+    "local_name",
+    "name",
+    "original_author",
+    "readonly_when_imported",
+    "sharing_mode",
+    "status",
+    "update_policy",
+    "version_time",
+}
+
+
+def _dependency_id(value: Any) -> str:
+    if isinstance(value, dict):
+        for key in ("id", "name", "skill", "ref"):
+            text = str(value.get(key) or "").strip()
+            if text:
+                return text
+        return ""
+    return str(value or "").strip()
+
+
+def _collect_dependency_items(value: Any, requirement: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        for key, nested_requirement in (("required", "required"), ("recommended", "recommended"), ("optional", "optional")):
+            if key in value:
+                items.extend(_collect_dependency_items(value.get(key), nested_requirement))
+        direct_id = _dependency_id(value)
+        if direct_id:
+            item: dict[str, Any] = {"id": direct_id, "requirement": str(value.get("requirement") or requirement)}
+            for key in DEPENDENCY_PASSTHROUGH_KEYS:
+                if key in value and value.get(key) is not None:
+                    item[key] = value.get(key)
+            items.append(item)
+        return items
+    if isinstance(value, list):
+        for item in value:
+            items.extend(_collect_dependency_items(item, requirement))
+        return items
+    direct_id = _dependency_id(value)
+    if direct_id:
+        items.append({"id": direct_id, "requirement": requirement})
+    return items
+
+
+def _entry_dependency_items(entry_data: dict[str, Any]) -> list[dict[str, Any]]:
+    collected: list[dict[str, Any]] = []
+    for key, requirement in (
+        ("required_skills", "required"),
+        ("recommended_skills", "recommended"),
+        ("skill_dependencies", "required"),
+        ("skills", "required"),
+    ):
+        if key in entry_data:
+            collected.extend(_collect_dependency_items(entry_data.get(key), requirement))
+    proposal = entry_data.get("organization_proposal") if isinstance(entry_data.get("organization_proposal"), dict) else {}
+    if "skill_dependencies" in proposal:
+        collected.extend(_collect_dependency_items(proposal.get("skill_dependencies"), "required"))
+    return collected
+
+
+def _has_value(value: Any) -> bool:
+    return value is not None and value != ""
+
+
+def extract_skill_dependencies(entry_data: dict[str, Any]) -> list[dict[str, Any]]:
+    collected = _entry_dependency_items(entry_data)
+
+    by_id: dict[str, dict[str, Any]] = {}
+    rank = {"required": 0, "recommended": 1, "optional": 2}
+    for item in collected:
+        skill_id = str(item["id"]).strip()
+        if not skill_id:
+            continue
+        requirement = item.get("requirement") or "required"
+        candidate = {key: value for key, value in item.items() if _has_value(value)}
+        candidate["id"] = skill_id
+        candidate["requirement"] = requirement
+        existing = by_id.get(skill_id)
+        if existing is None or rank.get(requirement, 9) < rank.get(existing.get("requirement", ""), 9):
+            merged = dict(existing or {})
+            merged.update(candidate)
+            by_id[skill_id] = merged
+        else:
+            for key, value in candidate.items():
+                existing.setdefault(key, value)
+    return list(by_id.values())
+
+
+def extract_card_bound_skill_bundle_dependencies(entry_data: dict[str, Any]) -> list[dict[str, Any]]:
+    dependencies: list[dict[str, Any]] = []
+    for item in _entry_dependency_items(entry_data):
+        if not isinstance(item, dict):
+            continue
+        sharing_mode = str(item.get("sharing_mode") or "").strip()
+        bundle_id = str(item.get("bundle_id") or "").strip()
+        bundle_path = str(item.get("bundle_path") or "").strip()
+        if sharing_mode == "card-bound-bundle" or (bundle_id and bundle_path):
+            dependencies.append(item)
+    return dependencies
+
+
+def _skill_search_roots(repo_root: Path, codex_home: Path | None = None) -> list[Path]:
+    roots = [repo_root / ".agents" / "skills"]
+    if codex_home is None:
+        env_home = os.environ.get("CODEX_HOME", "").strip()
+        codex_home = Path(env_home) if env_home else Path.home() / ".codex"
+    roots.append(codex_home / "skills")
+    return roots
+
+
+def _read_skill_frontmatter(skill_path: Path) -> dict[str, Any]:
+    text = skill_path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    payload = yaml.safe_load(parts[1]) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _safe_segment(value: Any, *, fallback: str = "item") -> str:
+    safe = "".join(char if char.isalnum() or char in {"-", "_", "."} else "-" for char in str(value or ""))
+    safe = safe.strip(".-")
+    return safe[:120] or fallback
+
+
+def _safe_hash_segment(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.startswith("sha256:"):
+        text = "sha256-" + text.removeprefix("sha256:")
+    return _safe_segment(text, fallback="hash")
+
+
+def _compact_bundle_version_segment(version_time: Any, content_hash: Any) -> str:
+    time_text = "".join(char for char in str(version_time or "") if char.isalnum())[:16] or "version"
+    digest = hashlib.sha256(f"{version_time}|{content_hash}".encode("utf-8")).hexdigest()[:12]
+    return _safe_segment(f"{time_text}-{digest}", fallback="version")
+
+
+def _parse_bundle_version_time(value: Any) -> str:
+    text = str(value or "").strip()
+    return text or utc_now_iso()
+
+
+def _latest_version(versions: list[dict[str, Any]]) -> dict[str, Any]:
+    if not versions:
+        return {}
+    return sorted(
+        versions,
+        key=lambda item: (
+            _parse_bundle_version_time(item.get("version_time") or item.get("exported_at")),
+            str(item.get("content_hash") or ""),
+        ),
+    )[-1]
+
+
+def local_skill_bundle_state_path(repo_root: Path, local_skill_ref: str) -> Path:
+    return Path(repo_root) / LOCAL_SKILL_BUNDLE_STATE_ROOT / f"{_safe_segment(local_skill_ref, fallback='skill')}.yaml"
+
+
+def imported_skill_bundle_root(repo_root: Path) -> Path:
+    return Path(repo_root) / IMPORTED_SKILL_BUNDLE_ROOT
+
+
+def imported_skill_bundle_dir(repo_root: Path, bundle_id: str) -> Path:
+    return imported_skill_bundle_root(repo_root) / _safe_segment(bundle_id, fallback="bundle")
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def local_contributor_identity(repo_root: Path) -> str:
+    return installation_short_label(repo_root)
+
+
+def load_or_create_local_skill_bundle(
+    repo_root: Path,
+    local_skill_ref: str,
+    *,
+    content_hash: str = "",
+    version_time: str = "",
+    persist: bool = True,
+) -> dict[str, Any]:
+    """Return stable local card-bound Skill bundle metadata for a local Skill.
+
+    The bundle id is a lineage identifier. Content hashes identify exact
+    versions under that lineage.
+    """
+
+    repo_root = Path(repo_root)
+    local_skill_ref = str(local_skill_ref or "").strip()
+    path = local_skill_bundle_state_path(repo_root, local_skill_ref)
+    metadata = _read_yaml_mapping(path)
+    now = version_time or utc_now_iso()
+    if not metadata.get("bundle_id"):
+        metadata["bundle_id"] = new_card_id(
+            repo_root,
+            prefix="skill-bundle",
+            generated_at=now,
+            author_hint=local_contributor_identity(repo_root),
+        )
+    metadata["local_name"] = str(metadata.get("local_name") or local_skill_ref).strip()
+    metadata["original_author"] = str(metadata.get("original_author") or local_contributor_identity(repo_root)).strip()
+    metadata["created_at"] = str(metadata.get("created_at") or now)
+    metadata["readonly_when_imported"] = True
+    metadata["update_policy"] = SKILL_BUNDLE_UPDATE_POLICY
+    versions = metadata.get("versions") if isinstance(metadata.get("versions"), list) else []
+    normalized_versions = [item for item in versions if isinstance(item, dict)]
+    if content_hash:
+        existing = next(
+            (item for item in normalized_versions if str(item.get("content_hash") or "") == content_hash),
+            None,
+        )
+        if existing is None:
+            normalized_versions.append(
+                {
+                    "content_hash": content_hash,
+                    "version_time": now,
+                    "source": "local-author",
+                }
+            )
+        else:
+            existing["version_time"] = str(existing.get("version_time") or now)
+    metadata["versions"] = sorted(
+        normalized_versions,
+        key=lambda item: (
+            _parse_bundle_version_time(item.get("version_time")),
+            str(item.get("content_hash") or ""),
+        ),
+    )
+    metadata["latest_version"] = _latest_version(metadata["versions"])
+    if persist:
+        write_yaml_file(path, metadata)
+    return metadata
+
+
+def find_local_skill_metadata(repo_root: Path, skill_id: str, codex_home: Path | None = None) -> dict[str, Any] | None:
+    for root in _skill_search_roots(repo_root, codex_home=codex_home):
+        skill_path = root / skill_id / "SKILL.md"
+        if not skill_path.exists():
+            continue
+        metadata = _read_skill_frontmatter(skill_path)
+        skill_dir = skill_path.parent
+        return {
+            "id": skill_id,
+            "status": "installed",
+            "name": str(metadata.get("name") or skill_id),
+            "description": str(metadata.get("description") or ""),
+            "local_path_hint": str(skill_path.relative_to(repo_root)) if skill_path.is_relative_to(repo_root) else "",
+            "_source_dir": str(skill_dir),
+        }
+    return None
+
+
+def build_card_skill_dependency_manifest(
+    repo_root: Path,
+    entry_data: dict[str, Any],
+    *,
+    codex_home: Path | None = None,
+    persist_bundle_metadata: bool = True,
+) -> list[dict[str, Any]]:
+    manifest: list[dict[str, Any]] = []
+    for dependency in extract_skill_dependencies(entry_data):
+        skill_id = dependency["id"]
+        metadata = find_local_skill_metadata(repo_root, skill_id, codex_home=codex_home)
+        if metadata is None:
+            metadata = {
+                "id": skill_id,
+                "status": "missing",
+                "name": skill_id,
+                "description": "",
+                "local_path_hint": "",
+            }
+            manifest.append(
+                {
+                    **metadata,
+                    "requirement": dependency.get("requirement") or "required",
+                    "sharing_mode": "missing",
+                }
+            )
+            continue
+
+        source_dir = Path(str(metadata.get("_source_dir") or ""))
+        content_hash = skill_directory_content_hash(source_dir)
+        bundle_metadata = load_or_create_local_skill_bundle(
+            repo_root,
+            skill_id,
+            content_hash=content_hash,
+            persist=persist_bundle_metadata,
+        )
+        latest_version = bundle_metadata.get("latest_version") if isinstance(bundle_metadata.get("latest_version"), dict) else {}
+        version_time = str(latest_version.get("version_time") or utc_now_iso())
+        manifest.append(
+            {
+                **metadata,
+                "requirement": dependency.get("requirement") or "required",
+                "sharing_mode": "card-bound-bundle",
+                "bundle_id": str(bundle_metadata.get("bundle_id") or ""),
+                "local_name": str(bundle_metadata.get("local_name") or skill_id),
+                "original_author": str(bundle_metadata.get("original_author") or local_contributor_identity(repo_root)),
+                "content_hash": content_hash,
+                "version_time": version_time,
+                "readonly_when_imported": True,
+                "update_policy": SKILL_BUNDLE_UPDATE_POLICY,
+            }
+        )
+    return manifest
+
+
+def _public_dependency_payload(dependency: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in dependency.items() if not str(key).startswith("_")}
+
+
+def materialize_skill_bundle_dependencies(
+    dependencies: list[dict[str, Any]],
+    outbox_dir: Path,
+    *,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    materialized: list[dict[str, Any]] = []
+    outbox_dir = Path(outbox_dir)
+    for dependency in dependencies:
+        payload = _public_dependency_payload(dependency)
+        if dependency.get("sharing_mode") != "card-bound-bundle":
+            materialized.append(payload)
+            continue
+
+        source_dir = Path(str(dependency.get("_source_dir") or ""))
+        bundle_id = str(dependency.get("bundle_id") or "").strip()
+        version_time = str(dependency.get("version_time") or "").strip()
+        content_hash = str(dependency.get("content_hash") or "").strip()
+        bundle_root = (
+            outbox_dir
+            / "skills"
+            / _safe_segment(bundle_id, fallback="bundle")
+            / _compact_bundle_version_segment(version_time, content_hash)
+        )
+        skill_target = bundle_root / "skill"
+        metadata_target = bundle_root / "metadata.yaml"
+        payload["bundle_path"] = skill_target.relative_to(outbox_dir).as_posix()
+        payload["bundle_metadata_path"] = metadata_target.relative_to(outbox_dir).as_posix()
+        if not dry_run:
+            if not source_dir.exists():
+                payload["sharing_mode"] = "missing"
+                payload["status"] = "missing"
+            else:
+                if skill_target.exists():
+                    shutil.rmtree(skill_target)
+                skill_target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(
+                    source_dir,
+                    skill_target,
+                    ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+                )
+                write_yaml_file(
+                    metadata_target,
+                    {
+                        "bundle_id": bundle_id,
+                        "local_name": payload.get("local_name") or payload.get("id"),
+                        "original_author": payload.get("original_author"),
+                        "content_hash": content_hash,
+                        "version_time": version_time,
+                        "readonly_when_imported": True,
+                        "update_policy": SKILL_BUNDLE_UPDATE_POLICY,
+                        "source_skill_id": payload.get("id"),
+                        "source_skill_name": payload.get("name"),
+                    },
+                )
+        materialized.append(payload)
+    return materialized
+
+
+def normalize_skill_bundle_dependency(dependency: dict[str, Any]) -> dict[str, Any]:
+    bundle_id = str(dependency.get("bundle_id") or dependency.get("id") or "").strip()
+    version_time = str(dependency.get("version_time") or dependency.get("exported_at") or "").strip()
+    content_hash = str(dependency.get("content_hash") or "").strip()
+    return {
+        "bundle_id": bundle_id,
+        "id": str(dependency.get("id") or bundle_id).strip(),
+        "local_name": str(dependency.get("local_name") or dependency.get("name") or dependency.get("id") or "").strip(),
+        "name": str(dependency.get("name") or dependency.get("local_name") or dependency.get("id") or "").strip(),
+        "requirement": str(dependency.get("requirement") or "required").strip(),
+        "content_hash": content_hash,
+        "version_time": version_time,
+        "original_author": str(dependency.get("original_author") or "").strip(),
+        "readonly_when_imported": bool(dependency.get("readonly_when_imported", True)),
+        "update_policy": str(dependency.get("update_policy") or SKILL_BUNDLE_UPDATE_POLICY).strip(),
+        "status": str(dependency.get("status") or "").strip(),
+        "sharing_mode": str(dependency.get("sharing_mode") or "").strip(),
+    }
+
+
+def select_latest_skill_bundle_versions(dependencies: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_bundle: dict[str, list[dict[str, Any]]] = {}
+    for dependency in dependencies:
+        item = normalize_skill_bundle_dependency(dependency)
+        bundle_id = item["bundle_id"]
+        if not bundle_id:
+            continue
+        by_bundle.setdefault(bundle_id, []).append(item)
+    return {bundle_id: _latest_version(items) for bundle_id, items in by_bundle.items()}
+
+
+def install_imported_skill_bundle_version(
+    repo_root: Path,
+    dependency: dict[str, Any],
+    source_skill_dir: Path,
+    *,
+    source_card_id: str = "",
+    status: str = "approved",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    item = normalize_skill_bundle_dependency(dependency)
+    bundle_id = item["bundle_id"]
+    if not bundle_id:
+        return {"ok": False, "errors": ["bundle_id is required"], "status": "missing_bundle_id"}
+    source_skill_dir = Path(source_skill_dir)
+    if not source_skill_dir.exists():
+        return {"ok": False, "bundle_id": bundle_id, "errors": [f"Skill source does not exist: {source_skill_dir}"], "status": "missing_source"}
+
+    observed_hash = skill_directory_content_hash(source_skill_dir)
+    if item["content_hash"] and item["content_hash"] != observed_hash:
+        return {
+            "ok": False,
+            "bundle_id": bundle_id,
+            "errors": [f"Skill bundle content_hash mismatch: expected {item['content_hash']}, observed {observed_hash}"],
+            "status": "hash_mismatch",
+        }
+    content_hash = item["content_hash"] or observed_hash
+    version_time = item["version_time"] or utc_now_iso()
+    bundle_dir = imported_skill_bundle_dir(Path(repo_root), bundle_id)
+    version_dir = bundle_dir / "versions" / _safe_segment(version_time, fallback="version") / _safe_hash_segment(content_hash)
+    skill_target = version_dir / "skill"
+    metadata_path = version_dir / "metadata.yaml"
+    if not dry_run:
+        if skill_target.exists():
+            shutil.rmtree(skill_target)
+        skill_target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source_skill_dir, skill_target, ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+        source_cards = [source_card_id] if source_card_id else []
+        write_yaml_file(
+            metadata_path,
+            {
+                **item,
+                "content_hash": content_hash,
+                "version_time": version_time,
+                "status": status,
+                "readonly": True,
+                "source_cards": source_cards,
+            },
+        )
+    return {
+        "ok": True,
+        "bundle_id": bundle_id,
+        "content_hash": content_hash,
+        "version_time": version_time,
+        "path": str(version_dir),
+        "dry_run": dry_run,
+    }
+
+
+def consolidate_imported_skill_bundles(repo_root: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    root = imported_skill_bundle_root(Path(repo_root))
+    bundles: dict[str, list[dict[str, Any]]] = {}
+    if root.exists():
+        for metadata_path in sorted(root.glob("*/versions/*/*/metadata.yaml")):
+            payload = _read_yaml_mapping(metadata_path)
+            item = normalize_skill_bundle_dependency(payload)
+            bundle_id = item["bundle_id"] or metadata_path.parents[3].name
+            if not bundle_id:
+                continue
+            item["metadata_path"] = str(metadata_path)
+            item["version_dir"] = str(metadata_path.parent)
+            item["status"] = str(payload.get("status") or item.get("status") or "approved")
+            item["source_cards"] = payload.get("source_cards") if isinstance(payload.get("source_cards"), list) else []
+            bundles.setdefault(bundle_id, []).append(item)
+
+    kept: list[dict[str, Any]] = []
+    removed: list[dict[str, Any]] = []
+    for bundle_id, versions in bundles.items():
+        approved = [item for item in versions if str(item.get("status") or "").lower() in {"approved", "installed", ""}]
+        candidates = approved or versions
+        latest = _latest_version(candidates)
+        if not latest:
+            continue
+        kept.append(latest)
+        latest_dir = Path(str(latest.get("version_dir") or ""))
+        for item in versions:
+            version_dir = Path(str(item.get("version_dir") or ""))
+            if version_dir == latest_dir:
+                continue
+            removed.append(item)
+            if not dry_run and version_dir.exists():
+                shutil.rmtree(version_dir)
+        if not dry_run:
+            bundle_metadata_path = imported_skill_bundle_dir(Path(repo_root), bundle_id) / "metadata.yaml"
+            write_yaml_file(
+                bundle_metadata_path,
+                {
+                    "bundle_id": bundle_id,
+                    "latest_version": {
+                        key: latest.get(key)
+                        for key in (
+                            "content_hash",
+                            "version_time",
+                            "original_author",
+                            "local_name",
+                            "name",
+                            "status",
+                            "update_policy",
+                        )
+                        if latest.get(key) not in {None, ""}
+                    },
+                    "readonly": True,
+                    "source_cards": sorted({str(card) for item in versions for card in item.get("source_cards", []) if str(card).strip()}),
+                },
+            )
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "bundle_count": len(bundles),
+        "kept_count": len(kept),
+        "removed_count": len(removed),
+        "kept": kept,
+        "removed": removed,
+    }
+
+
+def normalize_skill_registry_item(item: dict[str, Any]) -> dict[str, Any]:
+    skill_id = str(item.get("id") or item.get("name") or "").strip()
+    status = str(item.get("status") or "").strip().lower()
+    return {
+        "id": skill_id,
+        "name": str(item.get("name") or skill_id).strip(),
+        "bundle_id": str(item.get("bundle_id") or "").strip(),
+        "status": status,
+        "version": str(item.get("version") or "").strip(),
+        "version_time": str(item.get("version_time") or "").strip(),
+        "owner": str(item.get("owner") or "").strip(),
+        "original_author": str(item.get("original_author") or item.get("owner") or "").strip(),
+        "submitted_by": str(item.get("submitted_by") or "").strip(),
+        "source_repo": str(item.get("source_repo") or "").strip(),
+        "source_path": str(item.get("source_path") or "").strip(),
+        "content_hash": str(item.get("content_hash") or "").strip(),
+        "description": str(item.get("description") or "").strip(),
+        "readonly_when_imported": bool(item.get("readonly_when_imported", True)),
+        "update_policy": str(item.get("update_policy") or SKILL_BUNDLE_UPDATE_POLICY).strip(),
+    }
+
+
+def load_organization_skill_registry(org_root: Path, registry_path: str = "skills/registry.yaml") -> dict[str, Any]:
+    path = Path(org_root) / registry_path
+    if not path.exists():
+        return {"ok": False, "errors": [f"skills registry does not exist: {registry_path}"], "skills": [], "by_id": {}, "by_bundle_id": {}}
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict) or not isinstance(payload.get("skills"), list):
+        return {"ok": False, "errors": ["skills registry must contain a skills list"], "skills": [], "by_id": {}, "by_bundle_id": {}}
+
+    errors: list[str] = []
+    skills: list[dict[str, Any]] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    versions_by_bundle: dict[str, list[dict[str, Any]]] = {}
+    for index, raw_item in enumerate(payload["skills"]):
+        if not isinstance(raw_item, dict):
+            errors.append(f"skills[{index}] must be a mapping")
+            continue
+        item = normalize_skill_registry_item(raw_item)
+        skill_id = item["id"]
+        if not skill_id:
+            errors.append(f"skills[{index}] is missing id")
+            continue
+        if item["status"] not in SKILL_REVIEW_STATES:
+            errors.append(f"skill {skill_id} has invalid status: {item['status']}")
+        if item["status"] == "approved":
+            if not item["version"] and not item["version_time"]:
+                errors.append(f"approved skill {skill_id} must pin version")
+            if not item["content_hash"].startswith("sha256:"):
+                errors.append(f"approved skill {skill_id} must pin sha256 content_hash")
+        skills.append(item)
+        by_id.setdefault(skill_id, item)
+        bundle_id = str(item.get("bundle_id") or "").strip()
+        if bundle_id:
+            versions_by_bundle.setdefault(bundle_id, []).append(item)
+
+    by_bundle_id = {bundle_id: _latest_version(items) for bundle_id, items in versions_by_bundle.items()}
+    return {"ok": not errors, "errors": errors, "skills": skills, "by_id": by_id, "by_bundle_id": by_bundle_id}
+
+
+def skill_auto_install_eligibility(skill: dict[str, Any], *, local_policy_allows: bool) -> dict[str, Any]:
+    reasons: list[str] = []
+    if not local_policy_allows:
+        reasons.append("local policy does not allow automatic organization Skill installation")
+    if str(skill.get("status") or "").strip().lower() != "approved":
+        reasons.append("Skill is not approved")
+    if not str(skill.get("version") or skill.get("version_time") or "").strip():
+        reasons.append("Skill version is not pinned")
+    if not str(skill.get("content_hash") or "").strip().startswith("sha256:"):
+        reasons.append("Skill content_hash is not sha256 pinned")
+    if not str(skill.get("source_repo") or "").strip():
+        reasons.append("Skill source_repo is missing")
+    return {
+        "eligible": not reasons,
+        "reasons": reasons,
+        "skill_id": str(skill.get("id") or skill.get("name") or "").strip(),
+    }
+
+
+def skill_directory_content_hash(skill_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(Path(skill_dir).rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(skill_dir)
+        if any(part in {".git", "__pycache__"} for part in relative.parts):
+            continue
+        if path.suffix == ".pyc":
+            continue
+        digest.update(relative.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def _safe_cache_name(value: str) -> str:
+    safe = "".join(char if char.isalnum() or char in {"-", "_", "."} else "-" for char in value)
+    safe = safe.strip(".-")
+    return safe[:80] or "organization-skill"
+
+
+def _run_git(args: list[str], *, cwd: Path | None = None) -> tuple[bool, str]:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd) if cwd is not None else None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        return False, str(exc)
+    output = (completed.stdout + completed.stderr).strip()
+    return completed.returncode == 0, output
+
+
+def _checkout_skill_source(skill: dict[str, Any], cache_root: Path) -> tuple[Path | None, str]:
+    source_repo = str(skill.get("source_repo") or "").strip()
+    version = str(skill.get("version") or skill.get("version_time") or "").strip()
+    local_source = Path(source_repo) if source_repo else Path()
+    if source_repo and local_source.exists():
+        return local_source, ""
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    checkout_dir = cache_root / _safe_cache_name(f"{skill.get('id')}-{version}")
+    if checkout_dir.exists():
+        ok, output = _run_git(["fetch", "--tags", "--prune"], cwd=checkout_dir)
+        if not ok:
+            return None, f"failed to fetch Skill source: {output}"
+    else:
+        ok, output = _run_git(["clone", source_repo, str(checkout_dir)])
+        if not ok:
+            return None, f"failed to clone Skill source: {output}"
+    ok, output = _run_git(["checkout", version], cwd=checkout_dir)
+    if not ok:
+        return None, f"failed to checkout Skill version {version}: {output}"
+    return checkout_dir, ""
+
+
+def _resolve_skill_source_dir(checkout_root: Path, skill: dict[str, Any]) -> Path | None:
+    source_path = str(skill.get("source_path") or "").strip()
+    skill_id = str(skill.get("id") or "").strip()
+    candidates = []
+    if source_path:
+        candidates.append(checkout_root / source_path)
+    if skill_id:
+        candidates.append(checkout_root / skill_id)
+    candidates.append(checkout_root)
+    for candidate in candidates:
+        if (candidate / "SKILL.md").exists():
+            return candidate
+    return None
+
+
+def resolve_skill_bundle_source_dir(
+    org_root: Path,
+    source_info: dict[str, Any],
+    dependency: dict[str, Any],
+) -> Path | None:
+    bundle_path = str(dependency.get("bundle_path") or "").strip()
+    if not bundle_path:
+        return None
+    bundle_relative = Path(bundle_path)
+    candidates: list[Path] = []
+    if bundle_relative.is_absolute():
+        candidates.append(bundle_relative)
+    else:
+        source_relative = Path(str(source_info.get("path") or ""))
+        if source_relative.parts:
+            candidates.append(Path(org_root) / source_relative.parent / bundle_relative)
+        candidates.append(Path(org_root) / bundle_relative)
+    for candidate in candidates:
+        if (candidate / "SKILL.md").exists():
+            return candidate
+    return None
+
+
+def install_approved_organization_skill(
+    skill: dict[str, Any],
+    *,
+    codex_home: Path | None = None,
+    cache_root: Path | None = None,
+    local_policy_allows: bool = False,
+    replace_existing: bool = False,
+) -> dict[str, Any]:
+    normalized = normalize_skill_registry_item(skill)
+    eligibility = skill_auto_install_eligibility(normalized, local_policy_allows=local_policy_allows)
+    if not eligibility["eligible"]:
+        return {
+            "ok": False,
+            "skill_id": normalized["id"],
+            "status": "not_eligible",
+            "errors": eligibility["reasons"],
+        }
+
+    home = codex_home or Path(os.environ.get("CODEX_HOME", "") or Path.home() / ".codex")
+    cache = cache_root or home / ".cache" / "organization-skills"
+    checkout_root, checkout_error = _checkout_skill_source(normalized, cache)
+    if checkout_root is None:
+        return {"ok": False, "skill_id": normalized["id"], "status": "source_error", "errors": [checkout_error]}
+
+    source_dir = _resolve_skill_source_dir(checkout_root, normalized)
+    if source_dir is None:
+        return {
+            "ok": False,
+            "skill_id": normalized["id"],
+            "status": "missing_skill",
+            "errors": ["Skill source does not contain SKILL.md at source_path, skill id path, or repo root"],
+        }
+
+    observed_hash = skill_directory_content_hash(source_dir)
+    expected_hash = normalized["content_hash"]
+    if observed_hash != expected_hash:
+        return {
+            "ok": False,
+            "skill_id": normalized["id"],
+            "status": "hash_mismatch",
+            "errors": [f"Skill content_hash mismatch: expected {expected_hash}, observed {observed_hash}"],
+        }
+
+    install_name = normalized["bundle_id"] or normalized["id"]
+    install_dir = home / "skills" / _safe_segment(install_name, fallback=normalized["id"] or "organization-skill")
+    if install_dir.exists():
+        installed_hash = skill_directory_content_hash(install_dir)
+        if installed_hash == expected_hash:
+            return {
+                "ok": True,
+                "skill_id": normalized["id"],
+                "bundle_id": normalized["bundle_id"],
+                "status": "already_installed",
+                "install_path": str(install_dir),
+                "content_hash": installed_hash,
+            }
+        if not replace_existing:
+            return {
+                "ok": False,
+                "skill_id": normalized["id"],
+                "status": "existing_version_conflict",
+                "errors": ["A different local Skill version already exists; replacement was not allowed"],
+            }
+        shutil.rmtree(install_dir)
+
+    install_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_dir, install_dir, ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"))
+    installed_hash = skill_directory_content_hash(install_dir)
+    return {
+        "ok": True,
+        "skill_id": normalized["id"],
+        "bundle_id": normalized["bundle_id"],
+        "status": "installed",
+        "install_path": str(install_dir),
+        "content_hash": installed_hash,
+    }
+
+
+def annotate_dependencies_with_registry_status(
+    dependencies: list[dict[str, Any]],
+    registry: dict[str, Any],
+    *,
+    local_policy_allows_auto_install: bool = False,
+) -> list[dict[str, Any]]:
+    by_id = registry.get("by_id") if isinstance(registry.get("by_id"), dict) else {}
+    by_bundle_id = registry.get("by_bundle_id") if isinstance(registry.get("by_bundle_id"), dict) else {}
+    annotated: list[dict[str, Any]] = []
+    for dependency in dependencies:
+        skill_id = str(dependency.get("id") or "").strip()
+        bundle_id = str(dependency.get("bundle_id") or "").strip()
+        registry_item = by_bundle_id.get(bundle_id) if bundle_id and isinstance(by_bundle_id.get(bundle_id), dict) else None
+        if registry_item is None:
+            registry_item = by_id.get(skill_id) if isinstance(by_id.get(skill_id), dict) else None
+        if registry_item is None:
+            annotated.append(
+                {
+                    **dependency,
+                    "registry_status": "missing",
+                    "auto_install": {"eligible": False, "reasons": ["Skill is missing from organization registry"], "skill_id": skill_id},
+                }
+            )
+            continue
+        annotated.append(
+                {
+                    **dependency,
+                    "registry_status": registry_item.get("status"),
+                    "registry_version": registry_item.get("version") or registry_item.get("version_time"),
+                    "auto_install": skill_auto_install_eligibility(
+                    registry_item,
+                    local_policy_allows=local_policy_allows_auto_install,
+                ),
+            }
+        )
+    return annotated

--- a/local_kb/source_labels.py
+++ b/local_kb/source_labels.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+AUTHOR_KEYS = (
+    "author",
+    "created_by",
+    "uploaded_by",
+    "github_user",
+    "github_account",
+    "user",
+    "agent",
+)
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _source_payloads(data: dict[str, Any]) -> list[dict[str, Any]]:
+    source = data.get("source")
+    if isinstance(source, dict):
+        return [source]
+    if isinstance(source, list):
+        return [item for item in source if isinstance(item, dict)]
+    return []
+
+
+def author_label_for_entry(data: dict[str, Any], source_info: dict[str, Any]) -> str:
+    for payload in [data, *_source_payloads(data)]:
+        for key in AUTHOR_KEYS:
+            text = _first_text(payload.get(key))
+            if text:
+                return text
+    return _first_text(
+        source_info.get("author"),
+        source_info.get("github_user"),
+        source_info.get("organization_id"),
+        source_info.get("source_id"),
+        "local",
+    )
+
+
+def source_label_for_entry(source_info: dict[str, Any]) -> str:
+    kind = _first_text(source_info.get("kind"), "local")
+    scope = _first_text(source_info.get("scope"), "unknown")
+    if kind == "organization":
+        organization_id = _first_text(source_info.get("organization_id"), source_info.get("source_id"), "org")
+        return f"org/{organization_id}/{scope}"
+    if kind == "local":
+        return f"local/{scope}"
+    return _first_text(source_info.get("label"), f"{kind}/{scope}")
+
+
+def card_source_summary(data: dict[str, Any], source_info: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_label": source_label_for_entry(source_info),
+        "author_label": author_label_for_entry(data, source_info),
+        "read_only": bool(source_info.get("read_only")),
+    }

--- a/local_kb/store.py
+++ b/local_kb/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -16,6 +17,65 @@ except ImportError as exc:  # pragma: no cover
 
 
 DEFAULT_SCOPES = ("public", "private", "candidates")
+DEFAULT_ORGANIZATION_SCOPES = ("trusted", "candidates")
+
+
+def local_source_scope(scope: str) -> str:
+    if scope == "candidates":
+        return "candidate"
+    if scope in {"public", "private"}:
+        return scope
+    return "unknown"
+
+
+def build_local_entry_source(repo_root: Path, scope: str, path: Path) -> dict[str, Any]:
+    source_scope = local_source_scope(scope)
+    return {
+        "kind": "local",
+        "source_id": "local",
+        "scope": source_scope,
+        "label": f"local/{source_scope}",
+        "organization_id": "",
+        "source_repo": "",
+        "source_commit": "",
+        "read_only": False,
+        "editable": True,
+        "contribution_eligible": source_scope in {"public", "candidate"},
+        "path": os.path.relpath(path, repo_root),
+    }
+
+
+def organization_source_scope(scope: str) -> str:
+    if scope == "candidates":
+        return "candidate"
+    if scope == "trusted":
+        return "trusted"
+    return "unknown"
+
+
+def build_organization_entry_source(
+    org_root: Path,
+    organization_id: str,
+    scope: str,
+    path: Path,
+    *,
+    source_repo: str = "",
+    source_commit: str = "",
+) -> dict[str, Any]:
+    source_scope = organization_source_scope(scope)
+    return {
+        "kind": "organization",
+        "source_id": organization_id,
+        "scope": source_scope,
+        "label": f"org/{organization_id}/{source_scope}" if organization_id else f"org/{source_scope}",
+        "organization_id": organization_id,
+        "source_repo": source_repo,
+        "source_commit": source_commit,
+        "read_only": True,
+        "editable": False,
+        "contribution_eligible": source_scope == "candidate",
+        "path": os.path.relpath(path, org_root),
+    }
 
 
 def resolve_repo_root(value: str | os.PathLike[str]) -> Path:
@@ -69,7 +129,40 @@ def load_entries(repo_root: Path, scopes: Iterable[str] = DEFAULT_SCOPES) -> lis
             entry_id = str(data.get("id", "") or "").strip()
             if scope == "candidates" and entry_id and entry_id in rejected_candidates:
                 continue
-            entries.append(Entry(path=path, data=data))
+            entries.append(Entry(path=path, data=data, source=build_local_entry_source(repo_root, scope, path)))
+    return entries
+
+
+def load_organization_entries(
+    org_root: Path,
+    organization_id: str,
+    *,
+    source_repo: str = "",
+    source_commit: str = "",
+    scopes: Iterable[str] = DEFAULT_ORGANIZATION_SCOPES,
+) -> list[Entry]:
+    entries: list[Entry] = []
+    kb_root = Path(org_root) / "kb"
+    for scope in tuple(scopes):
+        target = kb_root / scope
+        if not target.exists():
+            continue
+        for path in sorted(target.rglob("*.yaml")):
+            data = load_yaml_file(path)
+            entries.append(
+                Entry(
+                    path=path,
+                    data=data,
+                    source=build_organization_entry_source(
+                        Path(org_root),
+                        organization_id,
+                        scope,
+                        path,
+                        source_repo=source_repo,
+                        source_commit=source_commit,
+                    ),
+                )
+            )
     return entries
 
 

--- a/local_kb/ui_data.py
+++ b/local_kb/ui_data.py
@@ -6,8 +6,15 @@ from typing import Any
 from local_kb.common import normalize_string_list, normalize_text, parse_route_segments, safe_float
 from local_kb.consolidate_events import load_history_events
 from local_kb.i18n import DEFAULT_LANGUAGE, localized_entry, localized_route_label, normalize_language
-from local_kb.search import get_guidance, get_predicted_result, search_entries
-from local_kb.store import load_entries
+from local_kb.adoption import blocked_organization_download_hashes, card_exchange_hash, dedupe_local_entries_by_exchange_hash
+from local_kb.search import get_guidance, get_predicted_result, search_entries, search_multi_source_entries
+from local_kb.skill_sharing import (
+    annotate_dependencies_with_registry_status,
+    extract_skill_dependencies,
+    load_organization_skill_registry,
+)
+from local_kb.source_labels import card_source_summary
+from local_kb.store import load_entries, load_organization_entries
 from local_kb.taxonomy import build_taxonomy_gap_report, build_taxonomy_view
 
 
@@ -36,6 +43,17 @@ def _entry_sort_key(item: dict[str, Any]) -> tuple[int, float, str]:
     )
 
 
+def _entry_display_path(entry: Any, repo_root: Path) -> str:
+    source = getattr(entry, "source", {}) if hasattr(entry, "source") else {}
+    source_path = str(source.get("path") or "").strip() if isinstance(source, dict) else ""
+    if source_path and source.get("kind") == "organization":
+        return source_path
+    try:
+        return entry.path.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(entry.path)
+
+
 def summarize_entry(
     entry: Any,
     repo_root: Path,
@@ -45,6 +63,7 @@ def summarize_entry(
     language: str = DEFAULT_LANGUAGE,
 ) -> dict[str, Any]:
     data = localized_entry(entry.data, normalize_language(language))
+    skill_dependencies = extract_skill_dependencies(entry.data)
     domain_path = parse_route_segments(data.get("domain_path", []))
     cross_index = normalize_string_list(data.get("cross_index", []))
     summary = {
@@ -60,9 +79,12 @@ def summarize_entry(
         "related_cards": normalize_string_list(data.get("related_cards", [])),
         "tags": data.get("tags", []),
         "trigger_keywords": data.get("trigger_keywords", []),
+        "skill_dependency_count": len(skill_dependencies),
         "predicted_result": get_predicted_result(data),
         "guidance": get_guidance(data),
-        "path": entry.path.relative_to(repo_root).as_posix(),
+        "path": _entry_display_path(entry, repo_root),
+        "source_info": getattr(entry, "source", {}),
+        **card_source_summary(data, getattr(entry, "source", {})),
         "route_reason": route_reason,
         "match_route": match_route or domain_path,
     }
@@ -107,8 +129,46 @@ def _cross_route_match(data: dict[str, Any], prefix: list[str]) -> list[str] | N
     return None
 
 
-def build_route_view_payload(repo_root: Path, route: str = "", language: str = DEFAULT_LANGUAGE) -> dict[str, Any]:
-    entries = load_entries(repo_root)
+def _load_organization_entries_from_sources(
+    organization_sources: list[dict[str, Any]] | None,
+) -> list[Any]:
+    organization_entries: list[Any] = []
+    for source in organization_sources or []:
+        org_root = Path(str(source.get("path") or source.get("local_path") or ""))
+        organization_id = str(source.get("organization_id") or source.get("id") or "").strip()
+        if not org_root.exists() or not organization_id:
+            continue
+        organization_entries.extend(
+            load_organization_entries(
+                org_root,
+                organization_id,
+                source_repo=str(source.get("source_repo") or source.get("repo_url") or ""),
+                source_commit=str(source.get("source_commit") or ""),
+            )
+        )
+    return organization_entries
+
+
+def _load_entries_for_views(repo_root: Path, organization_sources: list[dict[str, Any]] | None = None) -> list[Any]:
+    local_entries = dedupe_local_entries_by_exchange_hash(load_entries(repo_root))
+    if not organization_sources:
+        return local_entries
+    blocked_hashes = blocked_organization_download_hashes(repo_root)
+    organization_entries = [
+        entry
+        for entry in _load_organization_entries_from_sources(organization_sources)
+        if card_exchange_hash(entry.data) not in blocked_hashes
+    ]
+    return [*local_entries, *organization_entries]
+
+
+def build_route_view_payload(
+    repo_root: Path,
+    route: str = "",
+    language: str = DEFAULT_LANGUAGE,
+    organization_sources: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    entries = _load_entries_for_views(repo_root, organization_sources)
     prefix = parse_route_segments(route)
     taxonomy_view = build_taxonomy_view(repo_root, route="/".join(prefix))
     normalized_language = normalize_language(language)
@@ -164,6 +224,31 @@ def build_route_view_payload(repo_root: Path, route: str = "", language: str = D
     }
 
 
+def build_source_view_payload(
+    repo_root: Path,
+    source_kind: str,
+    language: str = DEFAULT_LANGUAGE,
+    organization_sources: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    source_kind = str(source_kind or "").strip().lower()
+    normalized_language = normalize_language(language)
+    deck = [
+        summarize_entry(
+            entry,
+            repo_root,
+            route_reason="source",
+            match_route=parse_route_segments(entry.data.get("domain_path", [])),
+            language=normalized_language,
+        )
+        for entry in _load_entries_for_views(repo_root, organization_sources)
+        if str((getattr(entry, "source", {}) or {}).get("kind") or "local").lower() == source_kind
+    ]
+    return {
+        "source_kind": source_kind,
+        "deck": sorted(deck, key=_entry_sort_key),
+    }
+
+
 def _entry_history(repo_root: Path, entry_id: str, max_events: int = 8) -> list[dict[str, Any]]:
     events = load_history_events(repo_root, max_events=400)
     matched: list[dict[str, Any]] = []
@@ -190,14 +275,99 @@ def _entry_history(repo_root: Path, entry_id: str, max_events: int = 8) -> list[
     return matched
 
 
-def build_card_detail_payload(repo_root: Path, entry_id: str, language: str = DEFAULT_LANGUAGE) -> dict[str, Any] | None:
+def _load_entries_for_detail(
+    repo_root: Path,
+    organization_sources: list[dict[str, Any]] | None = None,
+    *,
+    prefer_source_info: dict[str, Any] | None = None,
+) -> list[Any]:
+    local_entries = load_entries(repo_root)
+    organization_entries = _load_organization_entries_from_sources(organization_sources)
+    if (prefer_source_info or {}).get("kind") == "organization":
+        return [*organization_entries, *local_entries]
+    return [*local_entries, *organization_entries]
+
+
+def _entry_matches_source_info(entry: Any, source_info: dict[str, Any] | None) -> bool:
+    if not source_info:
+        return True
+    entry_source = getattr(entry, "source", {}) if hasattr(entry, "source") else {}
+    if not isinstance(entry_source, dict):
+        return False
+    for key in ("kind", "organization_id", "path"):
+        expected = str(source_info.get(key) or "").strip()
+        if expected and str(entry_source.get(key) or "").strip() != expected:
+            return False
+    return True
+
+
+def _merged_skill_registry(organization_sources: list[dict[str, Any]] | None) -> dict[str, Any]:
+    merged: dict[str, Any] = {"ok": True, "errors": [], "skills": [], "by_id": {}, "by_bundle_id": {}}
+    for source in organization_sources or []:
+        org_root = Path(str(source.get("path") or source.get("local_path") or ""))
+        if not org_root.exists():
+            continue
+        registry = load_organization_skill_registry(org_root)
+        if not registry.get("ok"):
+            merged["ok"] = False
+            merged["errors"].extend(registry.get("errors") or [])
+        merged["skills"].extend(registry.get("skills") or [])
+        for skill_id, item in (registry.get("by_id") or {}).items():
+            merged["by_id"][skill_id] = item
+        for bundle_id, item in (registry.get("by_bundle_id") or {}).items():
+            merged["by_bundle_id"][bundle_id] = item
+    return merged
+
+
+def build_skill_registry_payload(
+    organization_sources: list[dict[str, Any]] | None,
+    *,
+    local_policy_allows_auto_install: bool = False,
+) -> dict[str, Any]:
+    registry = _merged_skill_registry(organization_sources)
+    skills = []
+    for skill in registry.get("skills") or []:
+        annotated = {
+            **skill,
+            "auto_install": annotate_dependencies_with_registry_status(
+                [{"id": skill.get("id"), "requirement": "optional"}],
+                registry,
+                local_policy_allows_auto_install=local_policy_allows_auto_install,
+            )[0]["auto_install"],
+        }
+        skills.append(annotated)
+    return {
+        "ok": registry.get("ok"),
+        "errors": registry.get("errors") or [],
+        "skills": skills,
+        "counts": {
+            "candidate": sum(1 for item in skills if item.get("status") == "candidate"),
+            "approved": sum(1 for item in skills if item.get("status") == "approved"),
+            "rejected": sum(1 for item in skills if item.get("status") == "rejected"),
+        },
+    }
+
+
+def build_card_detail_payload(
+    repo_root: Path,
+    entry_id: str,
+    language: str = DEFAULT_LANGUAGE,
+    organization_sources: list[dict[str, Any]] | None = None,
+    source_info: dict[str, Any] | None = None,
+    local_policy_allows_skill_auto_install: bool = False,
+) -> dict[str, Any] | None:
     normalized_language = normalize_language(language)
-    for entry in load_entries(repo_root):
+    for entry in _load_entries_for_detail(repo_root, organization_sources, prefer_source_info=source_info):
         if _entry_id(entry) != entry_id:
+            continue
+        if not _entry_matches_source_info(entry, source_info):
             continue
         raw_data = entry.data
         data = localized_entry(entry.data, normalized_language)
         summary = summarize_entry(entry, repo_root, language=normalized_language)
+        is_local_entry = summary.get("source_info", {}).get("kind") != "organization"
+        dependencies = extract_skill_dependencies(raw_data)
+        registry = _merged_skill_registry(organization_sources)
         return {
             **summary,
             "if": data.get("if"),
@@ -207,7 +377,12 @@ def build_card_detail_payload(repo_root: Path, entry_id: str, language: str = DE
             "source": data.get("source"),
             "updated_at": data.get("updated_at"),
             "raw": raw_data,
-            "recent_history": _entry_history(repo_root, entry_id),
+            "skill_dependencies": annotate_dependencies_with_registry_status(
+                dependencies,
+                registry,
+                local_policy_allows_auto_install=local_policy_allows_skill_auto_install,
+            ),
+            "recent_history": _entry_history(repo_root, entry_id) if is_local_entry else [],
         }
     return None
 
@@ -247,6 +422,7 @@ def build_search_payload(
     route_hint: str = "",
     top_k: int = 12,
     language: str = DEFAULT_LANGUAGE,
+    organization_sources: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     results = [
         summarize_entry(
@@ -256,7 +432,13 @@ def build_search_payload(
             match_route=parse_route_segments(entry.data.get("domain_path", [])),
             language=language,
         )
-        for entry in search_entries(repo_root, query=query, path_hint=route_hint, top_k=top_k)
+        for entry in search_multi_source_entries(
+            repo_root,
+            query=query,
+            path_hint=route_hint,
+            top_k=top_k,
+            organization_sources=organization_sources,
+        )
     ]
     return {
         "query": query,

--- a/scripts/install_codex_kb.py
+++ b/scripts/install_codex_kb.py
@@ -41,6 +41,7 @@ def main() -> int:
             print(f"launcher_path: {payload['launcher_path']}")
             print(f"global_agents_path: {payload['global_agents_path']}")
             print(f"install_state_path: {payload['install_state_path']}")
+            print(f"maintenance_skills: {', '.join(payload.get('maintenance_skill_names', []))}")
             print("checklist:")
             for item in payload.get("checklist", []):
                 marker = "[OK]" if item.get("ok") else "[MISSING]"
@@ -68,6 +69,7 @@ def main() -> int:
         print(f"skill_path: {payload['skill_path']}")
         print(f"launcher_path: {payload['launcher_path']}")
         print(f"install_state_path: {payload['install_state_path']}")
+        print(f"maintenance_skills: {', '.join(payload.get('maintenance_skill_names', []))}")
     return 0
 
 

--- a/scripts/kb_org_check.py
+++ b/scripts/kb_org_check.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.org_checks import check_organization_repository, normalize_changed_file  # noqa: E402
+
+
+def _split_changed_files(values: list[str]) -> list[str]:
+    files: list[str] = []
+    for value in values:
+        for item in str(value or "").replace("\r", "\n").split("\n"):
+            for part in item.split(","):
+                text = normalize_changed_file(part)
+                if text:
+                    files.append(text)
+    return files
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run organization KB repository checks for GitHub automation.")
+    parser.add_argument("--org-root", default=".", help="Organization KB repository root.")
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="Changed file path. May be repeated; comma-separated values are accepted.",
+    )
+    parser.add_argument(
+        "--changed-files-file",
+        default="",
+        help="Text file containing changed paths, one per line.",
+    )
+    parser.add_argument(
+        "--enforce-low-risk",
+        action="store_true",
+        help="Fail if the changed files are not eligible for low-risk automatic merge.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    changed_values = list(args.changed_file or [])
+    if args.changed_files_file:
+        changed_values.append(Path(args.changed_files_file).read_text(encoding="utf-8"))
+    result = check_organization_repository(
+        Path(args.org_root),
+        changed_files=_split_changed_files(changed_values),
+        enforce_low_risk=args.enforce_low_risk,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_configure_github_repo.py
+++ b/scripts/kb_org_configure_github_repo.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.github_repo_config import configure_github_org_kb_repository, github_token_from_git_credential  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Configure GitHub auto-merge and branch protection for an organization KB repo.")
+    parser.add_argument("--repo-url", required=True)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--required-context", action="append", default=["organization-kb-checks"])
+    parser.add_argument("--token-env", default="GITHUB_TOKEN")
+    parser.add_argument("--use-git-credential", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    token = os.environ.get(args.token_env, "").strip()
+    if not token and args.use_git_credential:
+        token = github_token_from_git_credential()
+    result = configure_github_org_kb_repository(
+        args.repo_url,
+        token=token,
+        branch=args.branch,
+        required_contexts=args.required_context,
+        dry_run=args.dry_run,
+    )
+    safe_result = dict(result)
+    safe_result.pop("token", None)
+    print(json.dumps(safe_result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_contribute.py
+++ b/scripts/kb_org_contribute.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.org_contribution import prepare_organization_import_branch  # noqa: E402
+from local_kb.org_outbox import organization_outbox_dir  # noqa: E402
+from local_kb.store import resolve_repo_root  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare a local organization KB import branch from outbox proposals.")
+    parser.add_argument("--repo-root", default="auto")
+    parser.add_argument("--org-root", required=True)
+    parser.add_argument("--organization-id", required=True)
+    parser.add_argument("--contributor-id", required=True)
+    parser.add_argument("--outbox-dir", default="")
+    parser.add_argument("--branch-name", default="")
+    parser.add_argument("--no-commit", action="store_true")
+    parser.add_argument("--push", action="store_true", help="Push the prepared branch to the configured remote.")
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--base-branch", default="main")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    outbox_dir = Path(args.outbox_dir) if args.outbox_dir else organization_outbox_dir(repo_root, args.organization_id)
+    result = prepare_organization_import_branch(
+        Path(args.org_root),
+        outbox_dir,
+        contributor_id=args.contributor_id,
+        branch_name=args.branch_name,
+        commit=not args.no_commit,
+        push=args.push,
+        remote=args.remote,
+        base_branch=args.base_branch,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_install_github_automation.py
+++ b/scripts/kb_org_install_github_automation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.org_github_automation import install_github_automation_templates  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Install GitHub Actions automation templates into an organization KB repo.")
+    parser.add_argument("--org-root", required=True, help="Organization KB repository root.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing workflow files.")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    result = install_github_automation_templates(Path(args.org_root), overwrite=args.overwrite)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_install_skill.py
+++ b/scripts/kb_org_install_skill.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.skill_sharing import install_approved_organization_skill, load_organization_skill_registry  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Install one approved organization Skill after registry policy checks.")
+    parser.add_argument("--org-root", required=True)
+    parser.add_argument("--skill-id", required=True)
+    parser.add_argument("--bundle-id", default="")
+    parser.add_argument("--codex-home", default="")
+    parser.add_argument("--cache-root", default="")
+    parser.add_argument("--allow-auto-policy", action="store_true")
+    parser.add_argument("--replace-existing", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    registry = load_organization_skill_registry(Path(args.org_root))
+    skill = (registry.get("by_bundle_id") or {}).get(args.bundle_id) if args.bundle_id else None
+    if skill is None:
+        skill = (registry.get("by_id") or {}).get(args.skill_id)
+    if skill is None:
+        skill = (registry.get("by_bundle_id") or {}).get(args.skill_id)
+    if skill is None:
+        result = {"ok": False, "skill_id": args.skill_id, "status": "missing", "errors": ["Skill is not in organization registry"]}
+    else:
+        result = install_approved_organization_skill(
+            skill,
+            codex_home=Path(args.codex_home) if args.codex_home else None,
+            cache_root=Path(args.cache_root) if args.cache_root else None,
+            local_policy_allows=args.allow_auto_policy,
+            replace_existing=args.replace_existing,
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_maintainer.py
+++ b/scripts/kb_org_maintainer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.org_automation import run_organization_maintenance  # noqa: E402
+from local_kb.org_maintenance import build_organization_maintenance_report  # noqa: E402
+from local_kb.settings import load_desktop_settings, organization_sources_from_settings  # noqa: E402
+from local_kb.store import resolve_repo_root  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect an organization KB mirror for maintainer review.")
+    parser.add_argument("--repo-root", default="auto")
+    parser.add_argument("--org-root", default="", help="Organization KB mirror path. Omit to use validated desktop settings.")
+    parser.add_argument(
+        "--automation",
+        action="store_true",
+        help="Run the settings-gated organization maintenance automation entry point.",
+    )
+    parser.add_argument("--no-postflight", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    if args.automation:
+        result = run_organization_maintenance(repo_root, record_postflight=not args.no_postflight)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        if not result.get("ok"):
+            raise SystemExit(2)
+        return
+
+    organization_id = ""
+    if args.org_root:
+        org_root = Path(args.org_root)
+    else:
+        settings = load_desktop_settings(repo_root)
+        sources = organization_sources_from_settings(settings)
+        if not sources:
+            print(
+                json.dumps(
+                    {"ok": False, "errors": ["No validated organization source in desktop settings."]},
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            raise SystemExit(2)
+        source = sources[0]
+        org_root = Path(str(source["path"]))
+        organization_id = str(source.get("organization_id") or "")
+
+    report = build_organization_maintenance_report(org_root, repo_root=repo_root, organization_id=organization_id)
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    if not report.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kb_org_outbox.py
+++ b/scripts/kb_org_outbox.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _bootstrap_repo_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+
+_bootstrap_repo_imports()
+
+from local_kb.org_automation import run_organization_contribution  # noqa: E402
+from local_kb.org_outbox import build_organization_outbox  # noqa: E402
+from local_kb.settings import load_desktop_settings, organization_sources_from_settings  # noqa: E402
+from local_kb.store import resolve_repo_root  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build organization KB contribution outbox files.")
+    parser.add_argument("--repo-root", default="auto")
+    parser.add_argument("--organization-id", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--automation",
+        action="store_true",
+        help="Run the settings-gated organization contribution automation entry point.",
+    )
+    parser.add_argument("--prepare-branch", action="store_true")
+    parser.add_argument("--contributor-id", default="")
+    parser.add_argument("--branch-name", default="")
+    parser.add_argument("--no-commit", action="store_true")
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--base-branch", default="main")
+    parser.add_argument("--no-postflight", action="store_true")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    if args.automation:
+        result = run_organization_contribution(
+            repo_root,
+            dry_run=args.dry_run,
+            prepare_branch=args.prepare_branch,
+            contributor_id=args.contributor_id,
+            branch_name=args.branch_name,
+            commit=not args.no_commit,
+            push=args.push,
+            remote=args.remote,
+            base_branch=args.base_branch,
+            record_postflight=not args.no_postflight,
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        if not result.get("ok"):
+            raise SystemExit(2)
+        return
+
+    if not args.organization_id:
+        parser.error("--organization-id is required unless --automation is used")
+
+    organization_sources = organization_sources_from_settings(load_desktop_settings(repo_root))
+    result = build_organization_outbox(
+        repo_root,
+        organization_id=args.organization_id,
+        dry_run=args.dry_run,
+        organization_sources=organization_sources,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result.get("ok"):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/github/org-kb-auto-merge.yml
+++ b/templates/github/org-kb-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Organization KB Auto Merge
+
+on:
+  workflow_run:
+    workflows:
+      - Organization KB Checks
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-after-checks:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge labeled organization maintenance PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "No pull request found for completed workflow."
+            exit 0
+          fi
+          labels="$(gh pr view "$PR_NUMBER" -R "$REPO" --json labels --jq '.labels[].name')"
+          if ! printf '%s\n' "$labels" | grep -qx 'org-kb:auto-merge'; then
+            echo "PR #$PR_NUMBER does not have org-kb:auto-merge label."
+            exit 0
+          fi
+          is_draft="$(gh pr view "$PR_NUMBER" -R "$REPO" --json isDraft --jq '.isDraft')"
+          if [ "$is_draft" != "false" ]; then
+            echo "PR #$PR_NUMBER is draft; not merging."
+            exit 0
+          fi
+          gh pr merge "$PR_NUMBER" -R "$REPO" --squash --delete-branch

--- a/templates/github/org-kb-checks.yml
+++ b/templates/github/org-kb-checks.yml
@@ -1,0 +1,37 @@
+name: Organization KB Checks
+
+on:
+  pull_request:
+    paths:
+      - "khaos_org_kb.yaml"
+      - "kb/**"
+      - "skills/**"
+      - "docs/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  organization-kb-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out organization KB
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed files
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" > changed-files.txt
+          cat changed-files.txt
+
+      - name: Install check dependencies
+        shell: bash
+        run: python -m pip install pyyaml
+
+      - name: Validate organization KB
+        shell: bash
+        run: python .github/scripts/org_kb_check.py --org-root . --changed-files-file changed-files.txt --enforce-low-risk

--- a/templates/github/org_kb_check.py
+++ b/templates/github/org_kb_check.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+
+LOW_RISK_PREFIXES = ("kb/candidates/", "kb/imports/", "skills/candidates/")
+SKILL_REVIEW_STATES = {"candidate", "approved", "rejected"}
+SECRET_PATTERNS = (
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"(?im)^\s*(password|secret|api[_-]?key|access[_-]?token)\s*:\s*['\"]?[^'\"\s][^'\"]*"),
+)
+LOCAL_PATH_PATTERNS = (
+    re.compile(r"[A-Za-z]:\\Users\\"),
+    re.compile(r"/Users/[^/\s]+/"),
+    re.compile(r"/home/[^/\s]+/"),
+    re.compile(r"\.codex[\\/]+"),
+    re.compile(r"AppData\\"),
+)
+RAW_MACHINE_KEYS = {"hardware_id", "hardware_fingerprint", "machine_id", "device_id", "local_installation_id"}
+
+
+def normalize_changed_file(value: str) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    if not text or text.startswith("/") or re.match(r"^[A-Za-z]:", text):
+        return ""
+    parts = PurePosixPath(text).parts
+    if any(part in {"", ".", ".."} for part in parts):
+        return ""
+    return "/".join(parts)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def append_machine_key_errors(payload: Any, errors: list[str], path_label: str, key_path: str = "") -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            next_key = f"{key_path}.{key}" if key_path else str(key)
+            if str(key) in RAW_MACHINE_KEYS and str(value or "").strip():
+                errors.append(f"{path_label}: raw machine identifier is not allowed at {next_key}")
+            append_machine_key_errors(value, errors, path_label, next_key)
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload):
+            append_machine_key_errors(item, errors, path_label, f"{key_path}[{index}]")
+
+
+def check_manifest(root: Path) -> list[str]:
+    errors: list[str] = []
+    manifest_path = root / "khaos_org_kb.yaml"
+    if not manifest_path.exists():
+        return ["missing organization KB manifest: khaos_org_kb.yaml"]
+    manifest = load_yaml(manifest_path)
+    if manifest.get("kind") != "khaos-organization-kb":
+        errors.append("manifest kind must be khaos-organization-kb")
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if not str(manifest.get("organization_id") or "").strip():
+        errors.append("organization_id is required")
+    for relative in ("kb/trusted", "kb/candidates", "kb/imports", "skills/candidates"):
+        if not (root / relative).exists():
+            errors.append(f"required path does not exist: {relative}")
+    if not (root / "skills" / "registry.yaml").exists():
+        errors.append("skills registry does not exist: skills/registry.yaml")
+    return errors
+
+
+def check_paths(changed_files: list[str], enforce_low_risk: bool) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    blockers: list[str] = []
+    outside = [path for path in changed_files if not path.startswith(LOW_RISK_PREFIXES)]
+    if outside:
+        blockers.append("changed files are not all low-risk paths")
+        if enforce_low_risk:
+            errors.extend(f"path is not eligible for low-risk auto-merge: {path}" for path in outside)
+    if not changed_files:
+        blockers.append("changed files are not all low-risk paths")
+    return errors, blockers
+
+
+def scan_content(root: Path, changed_files: list[str]) -> list[str]:
+    errors: list[str] = []
+    files = changed_files or [
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file() and ".git" not in path.parts and path.suffix.lower() in {".yaml", ".yml", ".md", ".json", ".txt"}
+    ]
+    for relative in files:
+        path = root / relative
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if any(pattern.search(text) for pattern in SECRET_PATTERNS):
+            errors.append(f"{relative}: possible secret or credential pattern")
+        if any(pattern.search(text) for pattern in LOCAL_PATH_PATTERNS):
+            errors.append(f"{relative}: local machine path is not allowed")
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            append_machine_key_errors(load_yaml(path), errors, relative)
+    return errors
+
+
+def check_skill_registry(root: Path) -> list[str]:
+    errors: list[str] = []
+    payload = load_yaml(root / "skills" / "registry.yaml")
+    skills = payload.get("skills")
+    if not isinstance(skills, list):
+        return ["skills registry must contain a skills list"]
+    seen: set[str] = set()
+    for index, item in enumerate(skills):
+        if not isinstance(item, dict):
+            errors.append(f"skills[{index}] must be a mapping")
+            continue
+        skill_id = str(item.get("id") or item.get("name") or "").strip()
+        status = str(item.get("status") or "").strip()
+        if not skill_id:
+            errors.append(f"skills[{index}] is missing id")
+            continue
+        if skill_id in seen:
+            errors.append(f"duplicate skill id: {skill_id}")
+        seen.add(skill_id)
+        if status not in SKILL_REVIEW_STATES:
+            errors.append(f"skill {skill_id} has invalid status: {status}")
+        if status == "approved":
+            if not str(item.get("version") or "").strip():
+                errors.append(f"approved skill {skill_id} must pin version")
+            if not str(item.get("content_hash") or "").startswith("sha256:"):
+                errors.append(f"approved skill {skill_id} must pin sha256 content_hash")
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org-root", default=".")
+    parser.add_argument("--changed-files-file", default="")
+    parser.add_argument("--enforce-low-risk", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    root = Path(args.org_root)
+    changed_files = []
+    if args.changed_files_file:
+        changed_files = [
+            path
+            for path in (normalize_changed_file(line) for line in Path(args.changed_files_file).read_text(encoding="utf-8").splitlines())
+            if path
+        ]
+    path_errors, blockers = check_paths(changed_files, args.enforce_low_risk)
+    errors = [
+        *check_manifest(root),
+        *path_errors,
+        *scan_content(root, changed_files),
+        *check_skill_registry(root),
+    ]
+    result = {
+        "ok": not errors,
+        "auto_merge_eligible": bool(changed_files) and not errors and not blockers,
+        "errors": errors,
+        "auto_merge_blockers": blockers,
+        "changed_files": changed_files,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if errors:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/predictive-kb-preflight/AGENTS.md.template
+++ b/templates/predictive-kb-preflight/AGENTS.md.template
@@ -2,7 +2,8 @@
 
 - For almost any coding, planning, writing, or repository task, invoke `$predictive-kb-preflight` before starting the main work. Treat this as a required default recall step, not optional housekeeping.
 - This also applies to release publishing, release audits, README presentation passes, public template cleanup, and repository-boundary or privacy review.
-- For non-trivial tasks, do not treat the work as complete until one explicit KB postflight check has been performed. If the task exposed a reusable lesson, a skill/plugin usage lesson, a miss, a route gap, a card weakness, or a KB-process failure, record one structured observation before ending the task.
+- For non-trivial tasks, do not treat the work as complete until one explicit KB postflight check has been performed. If the task exposed a reusable lesson, a skill/plugin usage lesson, a subagent/delegation usage lesson, a miss, a route gap, a card weakness, or a KB-process failure, record one structured observation before ending the task.
 - Treat lessons about Codex skill/plugin selection, ordering, combination, fallback, or limitations as valid KB signals when they materially change task outcomes.
+- Treat lessons about Codex subagent/delegation selection, ordering, waiting, parallelization, fallback, overhead, or main-thread clarity as valid KB signals when they materially change task outcomes.
 - Keep trusted-card rewrites, candidate promotion, and deeper taxonomy maintenance in the dedicated KB maintenance thread unless the current task is explicitly about maintaining the KB itself.
 - When working inside the predictive KB repository and asked to install, enable, bootstrap, or verify the system on a machine, run `python scripts/install_codex_kb.py --json` and then `python scripts/install_codex_kb.py --check --json` before doing anything else.

--- a/templates/predictive-kb-preflight/SKILL.md.template
+++ b/templates/predictive-kb-preflight/SKILL.md.template
@@ -37,6 +37,7 @@ Preferred operating pattern:
 - For non-trivial work, use the launcher to run the KB scan first so the active task starts with retrieved local context instead of re-deriving it.
 - After the main task, treat KB postflight as part of done. Record one structured observation whenever the task exposed a miss, reusable lesson, route gap, card weakness, or KB-process failure.
 - Skill and plugin usage lessons count as reusable signals when a skill choice, ordering, combination, fallback, or limitation materially changed the result.
+- Subagent and delegation usage lessons count as reusable signals when spawning, avoiding, sequencing, waiting for, or parallelizing subagents materially changed speed, coordination overhead, context isolation, main-thread clarity, verification quality, or task outcome.
 - The launcher is subcommand-based: `python "{{LAUNCHER_PATH}}" <command> ...`. The normal preflight entry is `search`.
 - For compatibility, the launcher also treats common search-style calls without the explicit `search` subcommand as a search request.
 - For search, prefer `--route-hint`. The underlying local search script also accepts the older `--path-hint` name.
@@ -67,7 +68,7 @@ Preferred operating pattern:
 
 5. Treat retrieved cards as bounded context. Follow current user instructions over stored cards if they conflict.
 6. Finish the main task.
-7. Before finalizing any non-trivial task, run one explicit KB postflight check: did the task expose a reusable lesson, a skill/plugin usage lesson, a miss, a route gap, a card weakness, or a KB-process failure?
+7. Before finalizing any non-trivial task, run one explicit KB postflight check: did the task expose a reusable lesson, a skill/plugin usage lesson, a subagent/delegation usage lesson, a miss, a route gap, a card weakness, or a KB-process failure?
 8. If the postflight check found a meaningful signal, append one structured observation:
 
    ```powershell
@@ -98,6 +99,8 @@ Preferred operating pattern:
    Preserve `thread-ref`, `project-ref`, and `workspace-root` whenever you know them. Sleep maintenance uses that provenance together with timestamps to reconstruct same-project chronology instead of treating every observation as an isolated note.
 
    For skill/plugin usage lessons, name the relevant skill or plugin in the scenario or action fields and use a route that can be found from both the skill-facing workflow, such as `codex/workflow/skills`, and the task-facing condition that made the skill relevant.
+
+   For subagent/delegation usage lessons, name the relevant subagent role or delegation pattern in the scenario or action fields and use a route that can be found from both the delegation-facing workflow, such as `codex/workflow/subagents`, and the task-facing condition that made delegation relevant.
 
 9. If the explicit postflight check found no meaningful signal, make that explicit and end the KB flow there rather than silently forgetting to check.
 10. When the task included a worse path and a corrected path, prefer recording both sides explicitly. Those contrastive observations are often the easiest ones for later maintenance to turn into cards with useful alternative branches.

--- a/templates/predictive-kb-preflight/agents/openai.yaml
+++ b/templates/predictive-kb-preflight/agents/openai.yaml
@@ -4,4 +4,4 @@ policy:
 interface:
   display_name: "Predictive KB Preflight"
   short_description: "Consult the shared predictive KB before coding, planning, writing, or repository work"
-  default_prompt: "Use $predictive-kb-preflight implicitly as a required default preflight for coding, planning, writing, and repository work. Run the KB scan before substantive work, and for non-trivial tasks do not treat work as complete until one explicit KB postflight check has been performed. After meaningful work, record a KB follow-up observation whenever the task exposed a reusable signal, skill/plugin usage lesson, miss, route gap, card weakness, or KB-process failure."
+  default_prompt: "Use $predictive-kb-preflight implicitly as a required default preflight for coding, planning, writing, and repository work. Run the KB scan before substantive work, and for non-trivial tasks do not treat work as complete until one explicit KB postflight check has been performed. After meaningful work, record a KB follow-up observation whenever the task exposed a reusable signal, skill/plugin usage lesson, subagent/delegation usage lesson, miss, route gap, card weakness, or KB-process failure."

--- a/tests/org_helpers.py
+++ b/tests/org_helpers.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+from local_kb.org_sources import _run_git, connect_organization_source
+from local_kb.settings import ORGANIZATION_MODE, load_desktop_settings, organization_sources_from_settings, save_desktop_settings
+from local_kb.store import load_yaml_file, write_yaml_file
+
+
+ORGANIZATION_ID = "sandbox"
+
+
+def base_card(
+    entry_id: str,
+    title: str,
+    guidance: str,
+    *,
+    status: str = "trusted",
+    confidence: float = 0.8,
+    route: list[str] | None = None,
+    required_skills: list[str] | None = None,
+    author: str = "sandbox",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": entry_id,
+        "title": title,
+        "type": "model",
+        "scope": "public",
+        "status": status,
+        "confidence": confidence,
+        "domain_path": route or ["shared", "organization"],
+        "tags": ["shared", "organization"],
+        "trigger_keywords": ["shared", "organization"],
+        "author": author,
+        "if": {"notes": "A reusable organization sandbox scenario."},
+        "action": {"description": "Use this card in organization acceptance tests."},
+        "predict": {"expected_result": "Organization mode keeps local and shared knowledge separated."},
+        "use": {"guidance": guidance},
+    }
+    if required_skills:
+        payload["required_skills"] = required_skills
+    return payload
+
+
+def sandbox_overlap_scan_card(entry_id: str = "sandbox-overlap-scan") -> dict[str, Any]:
+    return base_card(
+        entry_id,
+        "Repository tasks scan local KB first",
+        "Scan the local KB before repository work so prior models surface before implementation starts.",
+        confidence=0.9,
+        route=["system", "knowledge-library", "retrieval"],
+    )
+
+
+def sandbox_overlap_release_card(entry_id: str = "sandbox-overlap-release") -> dict[str, Any]:
+    return base_card(
+        entry_id,
+        "Release hygiene before publishing",
+        "Check release notes, version state, and public README claims before publishing repository changes.",
+        confidence=0.86,
+        route=["repository", "release", "hygiene"],
+    )
+
+
+def sandbox_unique_merge_card(entry_id: str = "sandbox-unique-merge") -> dict[str, Any]:
+    return base_card(
+        entry_id,
+        "Organization auto-merge smoke test candidate",
+        "Use a low-risk import branch when validating organization auto-merge checks.",
+        status="candidate",
+        confidence=0.55,
+        route=["organization", "maintenance", "merge"],
+    )
+
+
+def sandbox_unique_skill_card(entry_id: str = "sandbox-unique-skill") -> dict[str, Any]:
+    return base_card(
+        entry_id,
+        "Record meaningful Skill-use evidence",
+        "When a card depends on a Skill, keep the card and Skill bundle together for organization review.",
+        status="candidate",
+        confidence=0.5,
+        route=["codex", "workflow", "skills"],
+        required_skills=["demo-skill"],
+    )
+
+
+def organization_sandbox_cards() -> dict[str, dict[str, Any]]:
+    return {
+        "overlap_scan": sandbox_overlap_scan_card(),
+        "overlap_release": sandbox_overlap_release_card(),
+        "unique_merge": sandbox_unique_merge_card(),
+        "unique_skill": sandbox_unique_skill_card(),
+    }
+
+
+def write_valid_org_repo(root: Path, *, include_sandbox_cards: bool = True) -> None:
+    write_yaml_file(
+        root / "khaos_org_kb.yaml",
+        {
+            "kind": "khaos-organization-kb",
+            "schema_version": 1,
+            "organization_id": ORGANIZATION_ID,
+            "kb": {
+                "trusted_path": "kb/trusted",
+                "candidates_path": "kb/candidates",
+                "imports_path": "kb/imports",
+            },
+            "skills": {
+                "registry_path": "skills/registry.yaml",
+                "candidates_path": "skills/candidates",
+            },
+        },
+    )
+    if include_sandbox_cards:
+        cards = organization_sandbox_cards()
+        write_yaml_file(root / "kb" / "trusted" / "overlap-scan.yaml", cards["overlap_scan"])
+        write_yaml_file(root / "kb" / "trusted" / "overlap-release.yaml", cards["overlap_release"])
+        write_yaml_file(root / "kb" / "candidates" / "unique-merge.yaml", cards["unique_merge"])
+        write_yaml_file(root / "kb" / "candidates" / "unique-skill.yaml", cards["unique_skill"])
+    else:
+        write_yaml_file(root / "kb" / "trusted" / "seed.yaml", {"id": "seed", "status": "trusted"})
+        (root / "kb" / "candidates").mkdir(parents=True, exist_ok=True)
+    (root / "kb" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+    (root / "kb" / "imports").mkdir(parents=True, exist_ok=True)
+    (root / "kb" / "imports" / ".gitkeep").write_text("", encoding="utf-8")
+    write_yaml_file(root / "skills" / "registry.yaml", {"skills": []})
+    (root / "skills" / "candidates").mkdir(parents=True, exist_ok=True)
+    (root / "skills" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+
+
+def init_git_repo(root: Path, *, message: str = "seed") -> None:
+    result = _run_git(["init"], cwd=root)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    commit_all(root, message=message)
+
+
+def commit_all(root: Path, *, message: str) -> str:
+    add = _run_git(["add", "."], cwd=root)
+    if add.returncode != 0:
+        raise AssertionError(add.stderr or add.stdout)
+    commit = _run_git(
+        ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", message],
+        cwd=root,
+    )
+    if commit.returncode != 0:
+        raise AssertionError(commit.stderr or commit.stdout)
+    rev = _run_git(["rev-parse", "HEAD"], cwd=root)
+    if rev.returncode != 0:
+        raise AssertionError(rev.stderr or rev.stdout)
+    return rev.stdout.strip()
+
+
+def connect_profile_to_org(profile_root: Path, org_repo: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    result = connect_organization_source(profile_root, str(org_repo))
+    if not result.get("ok"):
+        return result, []
+    save_desktop_settings(
+        profile_root,
+        {
+            "mode": ORGANIZATION_MODE,
+            "organization": result["settings"],
+        },
+    )
+    settings = load_desktop_settings(profile_root)
+    return result, organization_sources_from_settings(settings)
+
+
+def write_local_skill(repo_root: Path, skill_id: str = "demo-skill", *, body: str = "Use this Skill.") -> Path:
+    skill_dir = repo_root / ".agents" / "skills" / skill_id
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_id}\ndescription: Demo Skill for organization acceptance tests.\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def write_local_skill_backed_card(repo_root: Path, entry_id: str = "skill-backed-card") -> Path:
+    write_local_skill(repo_root)
+    path = repo_root / "kb" / "public" / f"{entry_id}.yaml"
+    write_yaml_file(
+        path,
+        base_card(
+            entry_id,
+            "Skill backed organization contribution",
+            "Export the card and its Skill bundle together for organization review.",
+            confidence=0.82,
+            route=["codex", "workflow", "skills"],
+            required_skills=["demo-skill"],
+            author="machine-a",
+        ),
+    )
+    return path
+
+
+def publish_outbox_to_org_candidates(org_root: Path, outbox_dir: Path, *, message: str = "Publish accepted organization candidates") -> list[str]:
+    org_root = Path(org_root)
+    outbox_dir = Path(outbox_dir)
+    created: list[str] = []
+    candidate_dir = org_root / "kb" / "candidates"
+    candidate_dir.mkdir(parents=True, exist_ok=True)
+    for path in sorted(outbox_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(outbox_dir)
+        target = candidate_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+        created.append(target.relative_to(org_root).as_posix())
+    if created:
+        commit_all(org_root, message=message)
+    return created
+
+
+def load_first_yaml(path: Path) -> dict[str, Any]:
+    files = sorted(Path(path).glob("*.yaml"))
+    if not files:
+        return {}
+    return load_yaml_file(files[0])

--- a/tests/test_card_ids.py
+++ b/tests/test_card_ids.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.card_ids import installation_identity_path, installation_short_label, new_card_id
+
+
+class CardIdTests(unittest.TestCase):
+    def test_new_card_id_uses_time_author_or_installation_and_random_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+
+            self.assertEqual(
+                new_card_id(
+                    repo_root,
+                    prefix="cand",
+                    generated_at="2026-04-24T01:02:03+00:00",
+                    author_hint="Alice Smith",
+                    random_code="abc123",
+                ),
+                "cand-20260424T010203Z-alice-smith-abc123",
+            )
+            self.assertFalse(installation_identity_path(repo_root).exists())
+
+            install_short = installation_short_label(repo_root)
+            installation_id = json.loads(installation_identity_path(repo_root).read_text(encoding="utf-8"))[
+                "local_installation_id"
+            ]
+            self.assertTrue(install_short.startswith("inst"))
+            self.assertEqual(install_short, "inst" + installation_id.replace("-", "")[:8])
+
+            generated = new_card_id(
+                repo_root,
+                prefix="card",
+                generated_at="2026-04-24T01:02:03Z",
+                random_code="def456",
+            )
+            self.assertEqual(generated, f"card-20260424T010203Z-{install_short}-def456")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_install.py
+++ b/tests/test_codex_install.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,6 +11,10 @@ from unittest import mock
 from local_kb.install import (
     AUTOMATION_MODEL_ENV_VAR,
     AUTOMATION_REASONING_EFFORT_ENV_VAR,
+    ORG_CONTRIBUTE_WINDOW,
+    ORG_MAINTENANCE_WINDOW,
+    REPO_AUTOMATION_SPECS,
+    automation_rrule_for_spec,
     build_installation_check,
     global_agents_path,
     install_codex_integration,
@@ -20,6 +25,21 @@ from local_kb.install import (
 def write_cmd(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"@echo off\r\n{body}\r\n", encoding="utf-8")
+
+
+def rrule_local_minute(rrule: str) -> int:
+    hour = re.search(r"BYHOUR=(\d+)", rrule)
+    minute = re.search(r"BYMINUTE=(\d+)", rrule)
+    if not hour or not minute:
+        raise AssertionError(f"rrule does not contain BYHOUR/BYMINUTE: {rrule}")
+    return int(hour.group(1)) * 60 + int(minute.group(1))
+
+
+def toml_string_value(text: str, key: str) -> str:
+    match = re.search(rf"^{re.escape(key)} = \"([^\"]*)\"$", text, re.MULTILINE)
+    if not match:
+        raise AssertionError(f"toml text does not contain string value for {key}")
+    return match.group(1)
 
 
 class CodexInstallTests(unittest.TestCase):
@@ -66,11 +86,37 @@ class CodexInstallTests(unittest.TestCase):
             self.assertTrue((codex_home / "automations" / "kb-sleep" / "automation.toml").exists())
             self.assertTrue((codex_home / "automations" / "kb-dream" / "automation.toml").exists())
             self.assertTrue((codex_home / "automations" / "kb-architect" / "automation.toml").exists())
+            self.assertTrue((codex_home / "automations" / "kb-org-contribute" / "automation.toml").exists())
+            self.assertTrue((codex_home / "automations" / "kb-org-maintenance" / "automation.toml").exists())
+            self.assertTrue((codex_home / "skills" / "kb-sleep-maintenance" / "SKILL.md").exists())
+            self.assertTrue((codex_home / "skills" / "kb-dream-pass" / "SKILL.md").exists())
+            self.assertTrue((codex_home / "skills" / "kb-architect-pass" / "SKILL.md").exists())
+            self.assertTrue((codex_home / "skills" / "kb-organization-contribute" / "SKILL.md").exists())
+            self.assertTrue((codex_home / "skills" / "kb-organization-maintenance" / "SKILL.md").exists())
             self.assertTrue(global_agents_path(codex_home).exists())
             self.assertTrue((shell_bin_dir / "git.cmd").exists())
             self.assertTrue((shell_bin_dir / "rg.exe").exists())
             self.assertEqual(payload["repo_root"], str(repo_root))
-            self.assertEqual(payload["automation_ids"], ["kb-sleep", "kb-dream", "kb-architect"])
+            self.assertEqual(
+                payload["maintenance_skill_names"],
+                [
+                    "kb-sleep-maintenance",
+                    "kb-dream-pass",
+                    "kb-architect-pass",
+                    "kb-organization-contribute",
+                    "kb-organization-maintenance",
+                ],
+            )
+            self.assertEqual(
+                payload["automation_ids"],
+                [
+                    "kb-sleep",
+                    "kb-dream",
+                    "kb-architect",
+                    "kb-org-contribute",
+                    "kb-org-maintenance",
+                ],
+            )
             self.assertEqual(payload["automation_runtime"], automation_runtime)
             self.assertEqual(payload["shell_tools"]["shell_bin_dir"], str(shell_bin_dir))
             self.assertTrue(payload["shell_tools"]["git_shim_installed"])
@@ -83,6 +129,7 @@ class CodexInstallTests(unittest.TestCase):
             self.assertIn("--route-hint", skill_text)
             self.assertIn("search-style calls without the explicit `search` subcommand", skill_text)
             self.assertIn("Skill and plugin usage lessons count as reusable signals", skill_text)
+            self.assertIn("Subagent and delegation usage lessons count as reusable signals", skill_text)
 
             openai_text = (
                 codex_home / "skills" / "predictive-kb-preflight" / "agents" / "openai.yaml"
@@ -91,15 +138,88 @@ class CodexInstallTests(unittest.TestCase):
             self.assertIn("record a KB follow-up observation", openai_text)
             self.assertIn("required default preflight", openai_text)
             self.assertIn("skill/plugin usage lesson", openai_text)
+            self.assertIn("subagent/delegation usage lesson", openai_text)
 
             global_agents_text = global_agents_path(codex_home).read_text(encoding="utf-8")
             self.assertIn("BEGIN MANAGED PREDICTIVE KB DEFAULTS", global_agents_text)
             self.assertIn("$predictive-kb-preflight", global_agents_text)
             self.assertIn("explicit KB postflight check", global_agents_text)
             self.assertIn("skill/plugin usage", global_agents_text)
+            self.assertIn("subagent/delegation usage", global_agents_text)
+
+            sleep_skill_text = (codex_home / "skills" / "kb-sleep-maintenance" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            sleep_skill_openai = (
+                codex_home / "skills" / "kb-sleep-maintenance" / "agents" / "openai.yaml"
+            ).read_text(encoding="utf-8")
+            self.assertIn("name: kb-sleep-maintenance", sleep_skill_text)
+            self.assertIn("MAINTENANCE_PROMPT.md", sleep_skill_text)
+            self.assertIn("mandatory similar-card merge checkpoint", sleep_skill_text)
+            self.assertIn("mandatory overloaded-card split checkpoint", sleep_skill_text)
+            self.assertIn("organization Skill bundle consolidation checkpoint", sleep_skill_text)
+            self.assertIn("Do not skip the merge, split, or Skill bundle consolidation checkpoint itself", sleep_skill_text)
+            self.assertIn("allow_implicit_invocation: false", sleep_skill_openai)
+            self.assertIn("$kb-sleep-maintenance", sleep_skill_openai)
+
+            dream_skill_text = (codex_home / "skills" / "kb-dream-pass" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            dream_skill_openai = (
+                codex_home / "skills" / "kb-dream-pass" / "agents" / "openai.yaml"
+            ).read_text(encoding="utf-8")
+            self.assertIn("name: kb-dream-pass", dream_skill_text)
+            self.assertIn("DREAM_PROMPT.md", dream_skill_text)
+            self.assertIn("allow_implicit_invocation: false", dream_skill_openai)
+            self.assertIn("$kb-dream-pass", dream_skill_openai)
+
+            architect_skill_text = (codex_home / "skills" / "kb-architect-pass" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            architect_skill_openai = (
+                codex_home / "skills" / "kb-architect-pass" / "agents" / "openai.yaml"
+            ).read_text(encoding="utf-8")
+            self.assertIn("name: kb-architect-pass", architect_skill_text)
+            self.assertIn("ARCHITECT_PROMPT.md", architect_skill_text)
+            self.assertIn("allow_implicit_invocation: false", architect_skill_openai)
+            self.assertIn("$kb-architect-pass", architect_skill_openai)
+
+            org_contribute_skill_text = (
+                codex_home / "skills" / "kb-organization-contribute" / "SKILL.md"
+            ).read_text(encoding="utf-8")
+            org_contribute_skill_openai = (
+                codex_home / "skills" / "kb-organization-contribute" / "agents" / "openai.yaml"
+            ).read_text(encoding="utf-8")
+            self.assertIn("name: kb-organization-contribute", org_contribute_skill_text)
+            self.assertIn("scripts/kb_org_outbox.py", org_contribute_skill_text)
+            self.assertIn("card-bound Skill bundle", org_contribute_skill_text)
+            self.assertIn("local latest version for that bundle", org_contribute_skill_text)
+            self.assertIn("allow_implicit_invocation: false", org_contribute_skill_openai)
+            self.assertIn("$kb-organization-contribute", org_contribute_skill_openai)
+
+            org_maintenance_skill_text = (
+                codex_home / "skills" / "kb-organization-maintenance" / "SKILL.md"
+            ).read_text(encoding="utf-8")
+            org_maintenance_skill_openai = (
+                codex_home / "skills" / "kb-organization-maintenance" / "agents" / "openai.yaml"
+            ).read_text(encoding="utf-8")
+            self.assertIn("name: kb-organization-maintenance", org_maintenance_skill_text)
+            self.assertIn("scripts/kb_org_maintainer.py", org_maintenance_skill_text)
+            self.assertIn("organization-level Sleep-like maintenance", org_maintenance_skill_text)
+            self.assertIn("organization candidate intake checkpoint", org_maintenance_skill_text)
+            self.assertIn("mandatory organization similar-card merge checkpoint", org_maintenance_skill_text)
+            self.assertIn("mandatory organization overloaded-card split checkpoint", org_maintenance_skill_text)
+            self.assertIn("Skill safety checkpoint", org_maintenance_skill_text)
+            self.assertIn("Skill bundle version checkpoint", org_maintenance_skill_text)
+            self.assertIn("latest approved version by `version_time`", org_maintenance_skill_text)
+            self.assertIn("GitHub merge-readiness checkpoint", org_maintenance_skill_text)
+            self.assertIn("organization-review", org_maintenance_skill_text)
+            self.assertIn("allow_implicit_invocation: false", org_maintenance_skill_openai)
+            self.assertIn("$kb-organization-maintenance", org_maintenance_skill_openai)
 
             sleep_toml = (codex_home / "automations" / "kb-sleep" / "automation.toml").read_text(encoding="utf-8")
             self.assertIn('kind = "cron"', sleep_toml)
+            self.assertIn("$kb-sleep-maintenance", sleep_toml)
             self.assertIn('rrule = "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=12;BYMINUTE=0"', sleep_toml)
             self.assertIn(f'model = "{automation_runtime["model"]}"', sleep_toml)
             self.assertIn(f'reasoning_effort = "{automation_runtime["reasoning_effort"]}"', sleep_toml)
@@ -112,6 +232,11 @@ class CodexInstallTests(unittest.TestCase):
             self.assertIn("rerun the relevant validation", sleep_toml)
             self.assertIn("sleep self-preflight", sleep_toml)
             self.assertIn("system/knowledge-library/maintenance", sleep_toml)
+            self.assertIn("mandatory similar-card merge checkpoint", sleep_toml)
+            self.assertIn("mandatory overloaded-card split checkpoint", sleep_toml)
+            self.assertIn("organization Skill bundle consolidation checkpoint", sleep_toml)
+            self.assertIn("latest approved version by version_time", sleep_toml)
+            self.assertIn("skip-with-reason decisions", sleep_toml)
             self.assertIn("sleep postflight check", sleep_toml)
             self.assertIn("structured maintenance observation", sleep_toml)
             self.assertIn("recursively consolidating", sleep_toml)
@@ -119,6 +244,7 @@ class CodexInstallTests(unittest.TestCase):
 
             dream_toml = (codex_home / "automations" / "kb-dream" / "automation.toml").read_text(encoding="utf-8")
             self.assertIn('kind = "cron"', dream_toml)
+            self.assertIn("$kb-dream-pass", dream_toml)
             self.assertIn('kb_dream.py', dream_toml)
             self.assertIn('rrule = "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=13;BYMINUTE=0"', dream_toml)
             self.assertIn(f'model = "{automation_runtime["model"]}"', dream_toml)
@@ -137,6 +263,7 @@ class CodexInstallTests(unittest.TestCase):
                 codex_home / "automations" / "kb-architect" / "automation.toml"
             ).read_text(encoding="utf-8")
             self.assertIn('kind = "cron"', architect_toml)
+            self.assertIn("$kb-architect-pass", architect_toml)
             self.assertIn('kb_architect.py', architect_toml)
             self.assertIn('rrule = "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=14;BYMINUTE=0"', architect_toml)
             self.assertIn(f'model = "{automation_runtime["model"]}"', architect_toml)
@@ -155,24 +282,161 @@ class CodexInstallTests(unittest.TestCase):
             self.assertIn("validation bundle", architect_toml)
             self.assertIn("postflight observation status", architect_toml)
 
+            org_contribute_toml = (
+                codex_home / "automations" / "kb-org-contribute" / "automation.toml"
+            ).read_text(encoding="utf-8")
+            self.assertIn('kind = "cron"', org_contribute_toml)
+            self.assertIn("$kb-organization-contribute", org_contribute_toml)
+            self.assertIn("scripts/kb_org_outbox.py", org_contribute_toml)
+            self.assertIn('schedule_policy = "stable-jitter"', org_contribute_toml)
+            self.assertIn('schedule_window = "10:00-13:59"', org_contribute_toml)
+            org_contribute_minute = rrule_local_minute(toml_string_value(org_contribute_toml, "rrule"))
+            self.assertGreaterEqual(org_contribute_minute, ORG_CONTRIBUTE_WINDOW[0])
+            self.assertLessEqual(org_contribute_minute, ORG_CONTRIBUTE_WINDOW[1])
+            self.assertIn(f'model = "{automation_runtime["model"]}"', org_contribute_toml)
+            self.assertIn(f'reasoning_effort = "{automation_runtime["reasoning_effort"]}"', org_contribute_toml)
+            self.assertIn("desktop settings", org_contribute_toml)
+            self.assertIn("validated organization repository", org_contribute_toml)
+            self.assertIn("successful no-op", org_contribute_toml)
+            self.assertIn("KB preflight", org_contribute_toml)
+            self.assertIn("content-hash-gated outbox", org_contribute_toml)
+            self.assertIn("prior download hashes", org_contribute_toml)
+            self.assertIn("prior upload hashes", org_contribute_toml)
+            self.assertIn("card-bound Skill bundles", org_contribute_toml)
+            self.assertIn("bundle_id", org_contribute_toml)
+            self.assertIn("local latest version for that bundle", org_contribute_toml)
+            self.assertIn("KB postflight", org_contribute_toml)
+
+            org_maintenance_toml = (
+                codex_home / "automations" / "kb-org-maintenance" / "automation.toml"
+            ).read_text(encoding="utf-8")
+            self.assertIn('kind = "cron"', org_maintenance_toml)
+            self.assertIn("$kb-organization-maintenance", org_maintenance_toml)
+            self.assertIn("scripts/kb_org_maintainer.py", org_maintenance_toml)
+            self.assertIn("organization-level Sleep-like maintenance", org_maintenance_toml)
+            self.assertIn('schedule_policy = "stable-jitter"', org_maintenance_toml)
+            self.assertIn('schedule_window = "14:00-16:00"', org_maintenance_toml)
+            org_maintenance_minute = rrule_local_minute(toml_string_value(org_maintenance_toml, "rrule"))
+            self.assertGreaterEqual(org_maintenance_minute, ORG_MAINTENANCE_WINDOW[0])
+            self.assertLessEqual(org_maintenance_minute, ORG_MAINTENANCE_WINDOW[1])
+            self.assertIn(f'model = "{automation_runtime["model"]}"', org_maintenance_toml)
+            self.assertIn(f'reasoning_effort = "{automation_runtime["reasoning_effort"]}"', org_maintenance_toml)
+            self.assertIn("desktop settings", org_maintenance_toml)
+            self.assertIn("organization maintenance participation", org_maintenance_toml)
+            self.assertIn("successful no-op", org_maintenance_toml)
+            self.assertIn("KB preflight", org_maintenance_toml)
+            self.assertIn("organization candidate intake checkpoint", org_maintenance_toml)
+            self.assertIn("content-hash checkpoint", org_maintenance_toml)
+            self.assertIn("mandatory organization similar-card merge checkpoint", org_maintenance_toml)
+            self.assertIn("mandatory organization overloaded-card split checkpoint", org_maintenance_toml)
+            self.assertIn("candidate decision checkpoint", org_maintenance_toml)
+            self.assertIn("Skill safety checkpoint", org_maintenance_toml)
+            self.assertIn("Skill bundle version checkpoint", org_maintenance_toml)
+            self.assertIn("GitHub merge-readiness checkpoint", org_maintenance_toml)
+            self.assertIn("organization-review", org_maintenance_toml)
+            self.assertIn("Skill registry", org_maintenance_toml)
+            self.assertIn("duplicate content hashes", org_maintenance_toml)
+            self.assertIn("duplicate entry ids", org_maintenance_toml)
+            self.assertIn("bundle_id", org_maintenance_toml)
+            self.assertIn("original-author updates", org_maintenance_toml)
+            self.assertIn("latest approved version by version_time", org_maintenance_toml)
+            self.assertIn("do not auto-install", org_maintenance_toml)
+            self.assertIn("KB postflight", org_maintenance_toml)
+
             check = build_installation_check(repo_root=repo_root, codex_home=codex_home)
             self.assertTrue(check["ok"], check["issues"])
             self.assertEqual(check["automation_runtime"], automation_runtime)
             self.assertEqual(
+                check["maintenance_skill_names"],
+                [
+                    "kb-sleep-maintenance",
+                    "kb-dream-pass",
+                    "kb-architect-pass",
+                    "kb-organization-contribute",
+                    "kb-organization-maintenance",
+                ],
+            )
+            self.assertEqual(
+                [item["name"] for item in check["maintenance_skill_checks"]],
+                [
+                    "kb-sleep-maintenance",
+                    "kb-dream-pass",
+                    "kb-architect-pass",
+                    "kb-organization-contribute",
+                    "kb-organization-maintenance",
+                ],
+            )
+            self.assertEqual(
                 [item["id"] for item in check["automation_checks"]],
-                ["kb-sleep", "kb-dream", "kb-architect"],
+                [
+                    "kb-sleep",
+                    "kb-dream",
+                    "kb-architect",
+                    "kb-org-contribute",
+                    "kb-org-maintenance",
+                ],
             )
             checklist = {item["id"]: item for item in check["checklist"]}
             self.assertIn("codex_shell_tools", checklist)
             self.assertIn("strong_session_defaults", checklist)
+            self.assertIn("repo_maintenance_skills", checklist)
             self.assertIn("kb_architect_automation", checklist)
+            self.assertIn("kb_org_contribute_automation", checklist)
+            self.assertIn("kb_org_maintenance_automation", checklist)
             self.assertTrue(checklist["codex_shell_tools"]["ok"])
+            self.assertTrue(checklist["repo_maintenance_skills"]["ok"])
             self.assertTrue(checklist["kb_architect_automation"]["ok"])
+            self.assertTrue(checklist["kb_org_contribute_automation"]["ok"])
+            self.assertTrue(checklist["kb_org_maintenance_automation"]["ok"])
             self.assertTrue(checklist["strong_session_defaults"]["ok"])
             self.assertTrue(checklist["global_agents_block"]["ok"])
             self.assertTrue(checklist["global_skill_postflight"]["ok"])
             self.assertTrue(checklist["global_skill_skill_usage"]["ok"])
+            self.assertTrue(checklist["global_skill_subagent_usage"]["ok"])
             self.assertTrue(checklist["global_agents_skill_usage"]["ok"])
+            self.assertTrue(checklist["global_agents_subagent_usage"]["ok"])
+
+    def test_organization_automation_times_are_stable_and_windowed(self) -> None:
+        specs = {str(spec["id"]): spec for spec in REPO_AUTOMATION_SPECS}
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            identity_path = repo_root / ".local" / "khaos_brain_installation.json"
+            identity_path.parent.mkdir(parents=True, exist_ok=True)
+            identity_path.write_text(
+                json.dumps({"local_installation_id": "stable-installation-a"}),
+                encoding="utf-8",
+            )
+
+            contribute_first = automation_rrule_for_spec(specs["kb-org-contribute"], repo_root)
+            contribute_second = automation_rrule_for_spec(specs["kb-org-contribute"], repo_root)
+            maintenance_first = automation_rrule_for_spec(specs["kb-org-maintenance"], repo_root)
+            maintenance_second = automation_rrule_for_spec(specs["kb-org-maintenance"], repo_root)
+
+            self.assertEqual(contribute_first, contribute_second)
+            self.assertEqual(maintenance_first, maintenance_second)
+            contribute_minute = rrule_local_minute(contribute_first)
+            maintenance_minute = rrule_local_minute(maintenance_first)
+            self.assertGreaterEqual(contribute_minute, ORG_CONTRIBUTE_WINDOW[0])
+            self.assertLessEqual(contribute_minute, ORG_CONTRIBUTE_WINDOW[1])
+            self.assertGreaterEqual(maintenance_minute, ORG_MAINTENANCE_WINDOW[0])
+            self.assertLessEqual(maintenance_minute, ORG_MAINTENANCE_WINDOW[1])
+
+        first_machine_rrule = contribute_first
+        staggered = False
+        for index in range(1, 8):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                repo_root = Path(tmp_dir) / "repo"
+                identity_path = repo_root / ".local" / "khaos_brain_installation.json"
+                identity_path.parent.mkdir(parents=True, exist_ok=True)
+                identity_path.write_text(
+                    json.dumps({"local_installation_id": f"stable-installation-b-{index}"}),
+                    encoding="utf-8",
+                )
+                if automation_rrule_for_spec(specs["kb-org-contribute"], repo_root) != first_machine_rrule:
+                    staggered = True
+                    break
+
+        self.assertTrue(staggered)
 
     def test_automation_runtime_prefers_newest_full_gpt_model_with_deepest_reasoning(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_desktop_settings.py
+++ b/tests/test_desktop_settings.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.settings import (
+    ORGANIZATION_MODE,
+    PERSONAL_MODE,
+    load_desktop_settings,
+    maintenance_participation_status_from_settings,
+    organization_sources_from_settings,
+    save_desktop_settings,
+)
+
+
+class DesktopSettingsTests(unittest.TestCase):
+    def test_default_settings_are_personal_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            settings = load_desktop_settings(Path(tmp))
+
+        self.assertEqual(settings["mode"], PERSONAL_MODE)
+        self.assertFalse(settings["organization"]["validated"])
+        self.assertEqual(settings["organization"]["validation_status"], "not_configured")
+
+    def test_legacy_language_only_settings_still_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            settings_path = root / ".local" / "khaos_brain_desktop_settings.json"
+            settings_path.parent.mkdir(parents=True)
+            settings_path.write_text(json.dumps({"language": "zh-CN"}), encoding="utf-8")
+
+            settings = load_desktop_settings(root)
+
+        self.assertEqual(settings["language"], "zh-CN")
+        self.assertEqual(settings["mode"], PERSONAL_MODE)
+
+    def test_organization_mode_requires_validated_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            save_desktop_settings(
+                root,
+                {
+                    "mode": ORGANIZATION_MODE,
+                    "organization": {
+                        "repo_url": "https://github.com/example/khaos-org-kb-sandbox.git",
+                        "validation_status": "invalid",
+                        "validated": False,
+                    },
+                },
+            )
+
+            settings = load_desktop_settings(root)
+
+        self.assertEqual(settings["mode"], PERSONAL_MODE)
+        self.assertEqual(settings["organization"]["repo_url"], "https://github.com/example/khaos-org-kb-sandbox.git")
+
+    def test_valid_organization_settings_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            save_desktop_settings(
+                root,
+                {
+                    "language": "en",
+                    "mode": ORGANIZATION_MODE,
+                    "organization": {
+                        "repo_url": "https://github.com/example/khaos-org-kb-sandbox.git",
+                        "local_mirror_path": "C:/Users/example/.khaos/org/sandbox",
+                        "organization_id": "sandbox",
+                        "validated": True,
+                        "validation_status": "valid",
+                        "validation_message": "ok",
+                        "last_validated_at": "2026-04-24T15:00:00Z",
+                        "last_sync_commit": "abc1234",
+                        "last_sync_at": "2026-04-24T15:01:00Z",
+                    },
+                },
+            )
+
+            settings = load_desktop_settings(root)
+
+        self.assertEqual(settings["mode"], ORGANIZATION_MODE)
+        self.assertTrue(settings["organization"]["validated"])
+        self.assertEqual(settings["organization"]["organization_id"], "sandbox")
+        self.assertEqual(settings["organization"]["last_sync_commit"], "abc1234")
+
+    def test_organization_sources_are_only_active_for_valid_organization_mode(self) -> None:
+        settings = {
+            "mode": ORGANIZATION_MODE,
+            "organization": {
+                "repo_url": "https://github.com/example/khaos-org-kb-sandbox.git",
+                "local_mirror_path": "C:/mirror/sandbox",
+                "organization_id": "sandbox",
+                "validated": True,
+                "validation_status": "valid",
+                "last_sync_commit": "abc1234",
+            },
+        }
+
+        sources = organization_sources_from_settings(settings)
+
+        self.assertEqual(len(sources), 1)
+        self.assertEqual(sources[0]["path"], "C:/mirror/sandbox")
+        self.assertEqual(sources[0]["organization_id"], "sandbox")
+        settings["mode"] = PERSONAL_MODE
+        self.assertEqual(organization_sources_from_settings(settings), [])
+
+    def test_organization_maintenance_participation_requires_only_validated_organization(self) -> None:
+        settings = {
+            "mode": ORGANIZATION_MODE,
+            "organization": {
+                "repo_url": "https://github.com/example/khaos-org-kb-sandbox.git",
+                "local_mirror_path": "C:/mirror/sandbox",
+                "organization_id": "sandbox",
+                "validated": True,
+                "validation_status": "valid",
+                "organization_maintenance_requested": True,
+            },
+        }
+
+        status = maintenance_participation_status_from_settings(settings)
+
+        self.assertTrue(status["requested"])
+        self.assertTrue(status["available"])
+        self.assertIn("enabled", status["reason"])
+
+    def test_legacy_maintainer_mode_setting_maps_to_maintenance_participation(self) -> None:
+        settings = {
+            "mode": ORGANIZATION_MODE,
+            "organization": {
+                "repo_url": "https://github.com/example/khaos-org-kb-sandbox.git",
+                "local_mirror_path": "C:/mirror/sandbox",
+                "organization_id": "sandbox",
+                "validated": True,
+                "validation_status": "valid",
+                "maintainer_mode_requested": True,
+            },
+        }
+
+        status = maintenance_participation_status_from_settings(settings)
+
+        self.assertTrue(status["requested"])
+        self.assertTrue(status["available"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_e2e_multi_source_browsing.py
+++ b/tests/test_e2e_multi_source_browsing.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.settings import ORGANIZATION_MODE, load_desktop_settings, organization_sources_from_settings, save_desktop_settings
+from local_kb.store import load_yaml_file, write_yaml_file
+from local_kb.ui_data import build_card_detail_payload, build_search_payload, build_source_view_payload
+
+
+class MultiSourceBrowsingE2ETests(unittest.TestCase):
+    def _card(self, entry_id: str, title: str, guidance: str) -> dict:
+        return {
+            "id": entry_id,
+            "title": title,
+            "type": "model",
+            "scope": "public",
+            "status": "trusted",
+            "confidence": 0.9,
+            "domain_path": ["shared", "organization"],
+            "tags": ["shared", "organization"],
+            "trigger_keywords": ["shared", "organization"],
+            "if": {"notes": "Shared browsing scenario."},
+            "action": {"description": "Use the shared browsing card."},
+            "predict": {"expected_result": "The expected source is visible."},
+            "use": {"guidance": guidance},
+        }
+
+    def _save_organization_settings(self, repo: Path, org: Path) -> list[dict]:
+        save_desktop_settings(
+            repo,
+            {
+                "mode": ORGANIZATION_MODE,
+                "organization": {
+                    "repo_url": str(org),
+                    "local_mirror_path": str(org),
+                    "organization_id": "sandbox",
+                    "validated": True,
+                    "validation_status": "valid",
+                    "validation_message": "ok",
+                    "last_sync_commit": "abc1234",
+                },
+            },
+        )
+        return organization_sources_from_settings(load_desktop_settings(repo))
+
+    def test_settings_sourced_browsing_hides_same_hash_and_surfaces_new_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "machine"
+            org = root / "org"
+            same_guidance = "Use the same durable organization guidance."
+            write_yaml_file(repo / "kb" / "public" / "local.yaml", self._card("local-card", "Shared card", same_guidance))
+            write_yaml_file(org / "kb" / "trusted" / "org.yaml", self._card("org-card", "Shared card", same_guidance))
+            sources = self._save_organization_settings(repo, org)
+
+            initial_payload = build_search_payload(repo, "shared organization", organization_sources=sources)
+            local_source_payload = build_source_view_payload(repo, "local", organization_sources=sources)
+            organization_source_payload = build_source_view_payload(repo, "organization", organization_sources=sources)
+
+            changed = load_yaml_file(org / "kb" / "trusted" / "org.yaml")
+            changed["use"]["guidance"] = "Use the updated organization guidance."
+            write_yaml_file(org / "kb" / "trusted" / "org.yaml", changed)
+            changed_payload = build_search_payload(repo, "shared organization", organization_sources=sources)
+            organization_summary = next(
+                item for item in changed_payload["results"] if item["source_info"]["kind"] == "organization"
+            )
+            detail = build_card_detail_payload(
+                repo,
+                "org-card",
+                organization_sources=sources,
+                source_info=organization_summary["source_info"],
+            )
+
+        self.assertEqual([item["id"] for item in initial_payload["results"]], ["local-card"])
+        self.assertEqual([item["id"] for item in local_source_payload["deck"]], ["local-card"])
+        self.assertEqual(organization_source_payload["deck"], [])
+        self.assertEqual([item["source_info"]["kind"] for item in changed_payload["results"]], ["local", "organization"])
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail["id"], "org-card")
+        self.assertEqual(detail["source_info"]["kind"], "organization")
+        self.assertTrue(detail["read_only"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_e2e_organization_connection.py
+++ b/tests/test_e2e_organization_connection.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_sources import _run_git, connect_organization_source
+from local_kb.settings import (
+    ORGANIZATION_MODE,
+    PERSONAL_MODE,
+    load_desktop_settings,
+    organization_sources_from_settings,
+    save_desktop_settings,
+)
+from local_kb.store import write_yaml_file
+from local_kb.ui_data import build_search_payload
+
+
+class OrganizationConnectionE2ETests(unittest.TestCase):
+    def _write_valid_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(
+            root / "kb" / "trusted" / "org-card.yaml",
+            {
+                "id": "org-card",
+                "title": "Organization shared card",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.9,
+                "domain_path": ["shared", "organization"],
+                "tags": ["shared", "organization"],
+                "trigger_keywords": ["shared", "organization"],
+                "if": {"notes": "Shared organization connection scenario."},
+                "action": {"description": "Use the connected organization card."},
+                "predict": {"expected_result": "Organization search is active."},
+                "use": {"guidance": "Only appears after validated organization settings are active."},
+            },
+        )
+        (root / "kb" / "candidates").mkdir(parents=True, exist_ok=True)
+        (root / "kb" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+        (root / "kb" / "imports").mkdir(parents=True, exist_ok=True)
+        (root / "kb" / "imports" / ".gitkeep").write_text("", encoding="utf-8")
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": []})
+        (root / "skills" / "candidates").mkdir(parents=True, exist_ok=True)
+        (root / "skills" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+
+    def _commit_repo(self, root: Path) -> None:
+        self.assertEqual(0, _run_git(["init"], cwd=root).returncode)
+        self.assertEqual(0, _run_git(["add", "."], cwd=root).returncode)
+        result = _run_git(
+            ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+            cwd=root,
+        )
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+
+    def test_valid_source_activates_organization_mode_and_personal_switch_hides_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            repo = root / "machine"
+            self._write_valid_org_repo(source)
+            self._commit_repo(source)
+
+            connection = connect_organization_source(repo, str(source))
+            save_desktop_settings(
+                repo,
+                {
+                    "mode": ORGANIZATION_MODE,
+                    "organization": connection["settings"],
+                },
+            )
+            organization_settings = load_desktop_settings(repo)
+            organization_sources = organization_sources_from_settings(organization_settings)
+            organization_payload = build_search_payload(
+                repo,
+                "shared organization",
+                organization_sources=organization_sources,
+            )
+
+            save_desktop_settings(
+                repo,
+                {
+                    "mode": PERSONAL_MODE,
+                    "organization": organization_settings["organization"],
+                },
+            )
+            personal_settings = load_desktop_settings(repo)
+            personal_sources = organization_sources_from_settings(personal_settings)
+            personal_payload = build_search_payload(
+                repo,
+                "shared organization",
+                organization_sources=personal_sources,
+            )
+
+        self.assertTrue(connection["ok"], connection)
+        self.assertEqual(organization_settings["mode"], ORGANIZATION_MODE)
+        self.assertEqual(organization_settings["organization"]["organization_id"], "sandbox")
+        self.assertEqual(len(organization_sources), 1)
+        self.assertEqual([item["id"] for item in organization_payload["results"]], ["org-card"])
+        self.assertEqual(organization_payload["results"][0]["source_info"]["kind"], "organization")
+        self.assertEqual(personal_settings["mode"], PERSONAL_MODE)
+        self.assertEqual(personal_sources, [])
+        self.assertEqual(personal_payload["results"], [])
+
+    def test_invalid_source_cannot_force_organization_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "invalid-source"
+            repo = root / "machine"
+            source.mkdir(parents=True)
+            (source / "README.md").write_text("not an organization KB", encoding="utf-8")
+            self._commit_repo(source)
+
+            connection = connect_organization_source(repo, str(source))
+            save_desktop_settings(
+                repo,
+                {
+                    "mode": ORGANIZATION_MODE,
+                    "organization": connection["settings"],
+                },
+            )
+            settings = load_desktop_settings(repo)
+
+        self.assertFalse(connection["ok"], connection)
+        self.assertEqual(connection["settings"]["validation_status"], "invalid")
+        self.assertEqual(settings["mode"], PERSONAL_MODE)
+        self.assertFalse(settings["organization"]["validated"])
+        self.assertEqual(organization_sources_from_settings(settings), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_e2e_organization_maintenance_cleanup.py
+++ b/tests/test_e2e_organization_maintenance_cleanup.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_checks import check_organization_repository
+from local_kb.org_maintenance import build_organization_maintenance_report
+from local_kb.skill_sharing import (
+    consolidate_imported_skill_bundles,
+    install_imported_skill_bundle_version,
+    skill_directory_content_hash,
+)
+from local_kb.store import load_yaml_file, write_yaml_file
+
+
+class OrganizationMaintenanceCleanupE2ETests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(
+            root / "kb" / "trusted" / "canonical.yaml",
+            self._card("canonical-card", status="trusted", title="Canonical organization card"),
+        )
+        write_yaml_file(
+            root / "kb" / "candidates" / "weak-random.yaml",
+            self._card(
+                "weak-random",
+                status="candidate",
+                title="Random weak candidate",
+                guidance="Random unreviewed text with no durable predictive value.",
+                confidence=0.2,
+            ),
+        )
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(
+            root / "skills" / "registry.yaml",
+            {
+                "skills": [
+                    {
+                        "id": "approved-review-skill",
+                        "status": "approved",
+                        "version": "1.0.0",
+                        "source_repo": "https://example.invalid/skills.git",
+                        "content_hash": "sha256:" + "a" * 64,
+                    }
+                ]
+            },
+        )
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def _card(
+        self,
+        entry_id: str,
+        *,
+        status: str = "candidate",
+        title: str = "Shared candidate",
+        guidance: str = "Keep one canonical copy.",
+        confidence: float = 0.7,
+    ) -> dict:
+        return {
+            "id": entry_id,
+            "title": title,
+            "type": "model",
+            "scope": "public",
+            "status": status,
+            "confidence": confidence,
+            "domain_path": ["shared", "maintenance"],
+            "tags": ["shared", "maintenance"],
+            "trigger_keywords": ["shared", "maintenance"],
+            "if": {"notes": "A reusable organization maintenance scenario."},
+            "action": {"description": "Use the card to guide organization KB maintenance."},
+            "predict": {"expected_result": "Organization maintenance keeps the shared KB clean."},
+            "use": {"guidance": guidance},
+        }
+
+    def test_cleanup_report_flags_duplicate_hashes_but_does_not_mutate_org_cards(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            local_repo = root / "local"
+            self._write_org_repo(org)
+            duplicate_a = self._card("duplicate-a")
+            duplicate_b = dict(duplicate_a)
+            duplicate_b["id"] = "duplicate-b"
+            write_yaml_file(org / "kb" / "imports" / "alice" / "duplicate-a.yaml", duplicate_a)
+            write_yaml_file(org / "kb" / "imports" / "bob" / "duplicate-b.yaml", duplicate_b)
+            before_a = load_yaml_file(org / "kb" / "imports" / "alice" / "duplicate-a.yaml")
+            before_b = load_yaml_file(org / "kb" / "imports" / "bob" / "duplicate-b.yaml")
+
+            check = check_organization_repository(
+                org,
+                changed_files=[
+                    "kb/imports/alice/duplicate-a.yaml",
+                    "kb/imports/bob/duplicate-b.yaml",
+                ],
+                enforce_low_risk=True,
+            )
+            report = build_organization_maintenance_report(org, repo_root=local_repo)
+            after_a = load_yaml_file(org / "kb" / "imports" / "alice" / "duplicate-a.yaml")
+            after_b = load_yaml_file(org / "kb" / "imports" / "bob" / "duplicate-b.yaml")
+            weak_after = load_yaml_file(org / "kb" / "candidates" / "weak-random.yaml")
+
+        self.assertFalse(check["ok"], check)
+        self.assertIn("duplicate card content hashes require organization maintenance", check["errors"])
+        self.assertEqual(report["cleanup"]["duplicate_content_hash_count"], 1)
+        self.assertIn("review-duplicate-card-content-hashes", report["recommendations"])
+        self.assertEqual(report["cleanup"]["weak_card_rejection_apply"], "planned")
+        self.assertEqual(report["cleanup"]["similar_card_merge_apply"], "planned")
+        self.assertEqual(before_a, after_a)
+        self.assertEqual(before_b, after_b)
+        self.assertEqual(weak_after["status"], "candidate")
+
+    def test_imported_skill_bundle_cleanup_keeps_latest_version_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "local"
+            older_skill = root / "older-skill"
+            newer_skill = root / "newer-skill"
+            older_skill.mkdir(parents=True)
+            newer_skill.mkdir(parents=True)
+            (older_skill / "SKILL.md").write_text(
+                "---\nname: shared-skill\ndescription: Older shared Skill.\n---\n\nold",
+                encoding="utf-8",
+            )
+            (newer_skill / "SKILL.md").write_text(
+                "---\nname: shared-skill\ndescription: Newer shared Skill.\n---\n\nnew",
+                encoding="utf-8",
+            )
+            bundle_id = "skill-bundle-shared"
+            install_imported_skill_bundle_version(
+                repo,
+                {
+                    "id": "shared-skill",
+                    "bundle_id": bundle_id,
+                    "content_hash": skill_directory_content_hash(older_skill),
+                    "version_time": "2026-04-24T10:00:00Z",
+                    "original_author": "alice",
+                },
+                older_skill,
+                source_card_id="old-card",
+            )
+            install_imported_skill_bundle_version(
+                repo,
+                {
+                    "id": "shared-skill",
+                    "bundle_id": bundle_id,
+                    "content_hash": skill_directory_content_hash(newer_skill),
+                    "version_time": "2026-04-24T12:00:00Z",
+                    "original_author": "alice",
+                },
+                newer_skill,
+                source_card_id="new-card",
+            )
+
+            result = consolidate_imported_skill_bundles(repo)
+            remaining_skill_files = sorted(
+                (repo / ".local" / "organization_skills" / bundle_id / "versions").rglob("SKILL.md")
+            )
+            remaining_last_line = remaining_skill_files[0].read_text(encoding="utf-8").splitlines()[-1]
+            metadata = load_yaml_file(repo / ".local" / "organization_skills" / bundle_id / "metadata.yaml")
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["removed_count"], 1)
+        self.assertEqual(len(remaining_skill_files), 1)
+        self.assertEqual(remaining_last_line, "new")
+        self.assertEqual(metadata["latest_version"]["version_time"], "2026-04-24T12:00:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_e2e_skill_bundle_contribution_flow.py
+++ b/tests/test_e2e_skill_bundle_contribution_flow.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_checks import check_organization_repository
+from local_kb.org_contribution import prepare_organization_import_branch
+from local_kb.org_outbox import build_organization_outbox
+from local_kb.org_sources import _run_git
+from local_kb.store import load_yaml_file, write_yaml_file
+
+
+class SkillBundleContributionFlowE2ETests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "seed.yaml", {"id": "seed", "status": "trusted"})
+        (root / "kb" / "candidates").mkdir(parents=True, exist_ok=True)
+        (root / "kb" / "imports").mkdir(parents=True, exist_ok=True)
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": []})
+        (root / "skills" / "candidates").mkdir(parents=True, exist_ok=True)
+
+    def _write_skill_backed_local_card(self, repo: Path) -> None:
+        skill_dir = repo / ".agents" / "skills" / "demo-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: demo-skill\ndescription: Demo Skill for contribution e2e.\n---\n\nUse this Skill.",
+            encoding="utf-8",
+        )
+        write_yaml_file(
+            repo / "kb" / "public" / "skill-backed-card.yaml",
+            {
+                "id": "skill-backed-card",
+                "title": "Skill backed organization contribution",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.82,
+                "domain_path": ["codex", "workflow", "skills"],
+                "tags": ["skill", "organization"],
+                "trigger_keywords": ["skill", "organization"],
+                "required_skills": ["demo-skill"],
+                "if": {"notes": "A reusable card depends on a local Skill."},
+                "action": {"description": "Export the card and Skill bundle together."},
+                "predict": {"expected_result": "Organization imports keep the nested Skill bundle."},
+                "use": {"guidance": "Review the card and its Skill as one proposal."},
+            },
+        )
+
+    def _commit_repo(self, root: Path) -> None:
+        self.assertEqual(0, _run_git(["init"], cwd=root).returncode)
+        self.assertEqual(0, _run_git(["add", "."], cwd=root).returncode)
+        result = _run_git(
+            ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+            cwd=root,
+        )
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+
+    def test_outbox_contribution_preserves_nested_skill_bundle_and_passes_low_risk_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            machine = root / "machine-a"
+            org = root / "org"
+            self._write_org_repo(org)
+            self._commit_repo(org)
+            self._write_skill_backed_local_card(machine)
+
+            outbox = build_organization_outbox(machine, organization_id="sandbox")
+            proposal_path = Path(outbox["created"][0]["path"])
+            proposal = load_yaml_file(proposal_path)
+            dependency = proposal["organization_proposal"]["skill_dependencies"][0]
+            outbox_skill_path = Path(outbox["outbox_dir"]) / dependency["bundle_path"] / "SKILL.md"
+            outbox_metadata_path = Path(outbox["outbox_dir"]) / dependency["bundle_metadata_path"]
+
+            branch = prepare_organization_import_branch(
+                org,
+                Path(outbox["outbox_dir"]),
+                contributor_id="alice/main-laptop",
+                branch_name="contrib/alice/skill-bundle",
+            )
+            imported_proposal_path = org / "kb" / "imports" / "alice-main-laptop" / proposal_path.name
+            imported_proposal = load_yaml_file(imported_proposal_path)
+            imported_dependency = imported_proposal["organization_proposal"]["skill_dependencies"][0]
+            imported_skill_path = imported_proposal_path.parent / imported_dependency["bundle_path"] / "SKILL.md"
+            imported_metadata_path = imported_proposal_path.parent / imported_dependency["bundle_metadata_path"]
+            outbox_skill_exists = outbox_skill_path.exists()
+            outbox_metadata_exists = outbox_metadata_path.exists()
+            imported_skill_exists = imported_skill_path.exists()
+            imported_metadata_exists = imported_metadata_path.exists()
+            check = check_organization_repository(
+                org,
+                changed_files=branch["created_files"],
+                enforce_low_risk=True,
+            )
+
+        self.assertTrue(outbox["ok"], outbox)
+        self.assertEqual(outbox["created_count"], 1)
+        self.assertEqual(dependency["sharing_mode"], "card-bound-bundle")
+        self.assertTrue(outbox_skill_exists)
+        self.assertTrue(outbox_metadata_exists)
+        self.assertTrue(branch["ok"], branch)
+        self.assertIn("kb/imports/alice-main-laptop/skill-backed-card.yaml", branch["created_files"])
+        self.assertIn(imported_dependency["bundle_path"] + "/SKILL.md", "\n".join(branch["created_files"]))
+        self.assertTrue(imported_skill_exists)
+        self.assertTrue(imported_metadata_exists)
+        self.assertTrue(check["ok"], check)
+        self.assertTrue(check["auto_merge_eligible"], check)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_e2e_two_machine_cache_pool_lifecycle.py
+++ b/tests/test_e2e_two_machine_cache_pool_lifecycle.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.adoption import ADOPTION_KEY, adopt_organization_entry_by_source_info
+from local_kb.org_outbox import build_organization_outbox
+from local_kb.store import load_yaml_file, write_yaml_file
+from local_kb.ui_data import build_search_payload
+from tests.org_helpers import (
+    ORGANIZATION_ID,
+    connect_profile_to_org,
+    init_git_repo,
+    publish_outbox_to_org_candidates,
+    write_local_skill_backed_card,
+    write_valid_org_repo,
+)
+
+
+class TwoMachineCachePoolLifecycleE2ETests(unittest.TestCase):
+    def test_machine_b_syncs_org_cache_adopts_skill_card_and_exports_diverged_feedback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org_repo = root / "org-source"
+            machine_a = root / "machine-a"
+            machine_b = root / "machine-b"
+            write_valid_org_repo(org_repo, include_sandbox_cards=True)
+            init_git_repo(org_repo)
+
+            connect_a, sources_a = connect_profile_to_org(machine_a, org_repo)
+            connect_b_initial, sources_b_initial = connect_profile_to_org(machine_b, org_repo)
+            initial_b_payload = build_search_payload(
+                machine_b,
+                "Skill backed organization contribution",
+                organization_sources=sources_b_initial,
+            )
+
+            write_local_skill_backed_card(machine_a)
+            outbox_a = build_organization_outbox(
+                machine_a,
+                organization_id=ORGANIZATION_ID,
+                organization_sources=sources_a,
+            )
+            created_candidate_files = publish_outbox_to_org_candidates(org_repo, Path(outbox_a["outbox_dir"]))
+
+            connect_b_synced, sources_b_synced = connect_profile_to_org(machine_b, org_repo)
+            synced_b_payload = build_search_payload(
+                machine_b,
+                "Skill backed organization contribution",
+                organization_sources=sources_b_synced,
+            )
+            org_summary = next(
+                item for item in synced_b_payload["results"] if item["source_info"]["kind"] == "organization"
+            )
+            adoption_b = adopt_organization_entry_by_source_info(
+                machine_b,
+                "skill-backed-card",
+                sources_b_synced,
+                source_info=org_summary["source_info"],
+            )
+            adopted_path = Path(adoption_b["path"])
+            adopted = load_yaml_file(adopted_path)
+            adopted["use"]["guidance"] = "Machine B added practical feedback after using the organization card."
+            write_yaml_file(adopted_path, adopted)
+
+            outbox_b = build_organization_outbox(
+                machine_b,
+                organization_id=ORGANIZATION_ID,
+                organization_sources=sources_b_synced,
+            )
+            installed_skill_files = sorted((machine_b / ".local" / "organization_skills").rglob("SKILL.md"))
+            adopted_after = load_yaml_file(adopted_path)
+
+        self.assertTrue(connect_a["ok"], connect_a)
+        self.assertTrue(connect_b_initial["ok"], connect_b_initial)
+        self.assertNotIn("skill-backed-card", [item["id"] for item in initial_b_payload["results"]])
+        self.assertTrue(outbox_a["ok"], outbox_a)
+        self.assertEqual(outbox_a["created_count"], 1)
+        self.assertIn("kb/candidates/skill-backed-card.yaml", created_candidate_files)
+        self.assertTrue(connect_b_synced["ok"], connect_b_synced)
+        self.assertNotEqual(
+            connect_b_initial["settings"]["last_sync_commit"],
+            connect_b_synced["settings"]["last_sync_commit"],
+        )
+        self.assertEqual(org_summary["id"], "skill-backed-card")
+        self.assertEqual(org_summary["source_info"]["scope"], "candidate")
+        self.assertTrue(adoption_b["ok"], adoption_b)
+        self.assertTrue(adoption_b["created"])
+        self.assertEqual(len(installed_skill_files), 1)
+        self.assertEqual(adopted_after[ADOPTION_KEY]["organization_id"], ORGANIZATION_ID)
+        self.assertEqual(outbox_b["created_count"], 1, outbox_b)
+        self.assertEqual(outbox_b["created"][0]["proposal_kind"], "adopted-feedback")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_repo_config.py
+++ b/tests/test_github_repo_config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+
+from local_kb.github_repo_config import (
+    build_branch_protection_payload,
+    configure_github_org_kb_repository,
+    parse_github_owner_repo,
+)
+
+
+class GitHubRepoConfigTests(unittest.TestCase):
+    def test_parse_github_owner_repo_supports_https_and_ssh(self) -> None:
+        self.assertEqual(
+            parse_github_owner_repo("https://github.com/example-org/khaos-org-kb-sandbox.git"),
+            ("example-org", "khaos-org-kb-sandbox"),
+        )
+        self.assertEqual(
+            parse_github_owner_repo("git@github.com:example-org/khaos-org-kb-sandbox.git"),
+            ("example-org", "khaos-org-kb-sandbox"),
+        )
+
+    def test_branch_protection_payload_requires_expected_check_context(self) -> None:
+        payload = build_branch_protection_payload(["organization-kb-checks"])
+
+        self.assertEqual(payload["required_status_checks"]["contexts"], ["organization-kb-checks"])
+        self.assertTrue(payload["required_status_checks"]["strict"])
+        self.assertFalse(payload["allow_force_pushes"])
+        self.assertFalse(payload["allow_deletions"])
+
+    def test_configure_github_repo_dry_run_builds_expected_api_steps(self) -> None:
+        result = configure_github_org_kb_repository(
+            "https://github.com/example-org/khaos-org-kb-sandbox.git",
+            token="",
+            dry_run=True,
+        )
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["owner"], "example-org")
+        self.assertEqual(result["repo"], "khaos-org-kb-sandbox")
+        self.assertEqual([step["name"] for step in result["steps"]], ["enable-auto-merge", "protect-default-branch"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kb_consolidate_apply_worker1.py
+++ b/tests/test_kb_consolidate_apply_worker1.py
@@ -185,6 +185,55 @@ class ConsolidateApplyModeTests(unittest.TestCase):
                 created_candidate["action_key"],
             )
 
+    def test_new_candidate_apply_uses_content_hash_not_id_to_skip_existing_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            history_path = repo_root / "kb" / "history" / "events.jsonl"
+            history_path.parent.mkdir(parents=True, exist_ok=True)
+
+            event = {
+                "event_id": "obs-new-cand-1",
+                "event_type": "observation",
+                "created_at": "2026-04-19T08:09:00+00:00",
+                "source": {"kind": "task", "agent": "worker-1"},
+                "target": {
+                    "kind": "task-observation",
+                    "route_hint": ["work", "communication", "email"],
+                    "task_summary": "Need reusable email preference guidance",
+                },
+                "rationale": "next=new-candidate",
+                "context": {
+                    "suggested_action": "new-candidate",
+                    "predictive_observation": {
+                        "scenario": "Email workflow tasks repeatedly need route-specific preference guidance.",
+                        "action_taken": "Record a new-candidate observation for the communication email route.",
+                        "observed_result": "Maintenance can synthesize a candidate instead of losing the route gap.",
+                        "operational_use": "Prefer a route-specific email card when similar tasks recur.",
+                        "reuse_judgment": "Reusable for email workflow tasks.",
+                    },
+                },
+            }
+            history_path.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+            first = consolidate_history(
+                repo_root=repo_root,
+                run_id="apply-first",
+                apply_mode="new-candidates",
+            )
+            second = consolidate_history(
+                repo_root=repo_root,
+                run_id="apply-second",
+                apply_mode="new-candidates",
+            )
+
+            self.assertEqual(first["apply_summary"]["created_candidate_count"], 1)
+            first_id = first["apply_summary"]["created_candidates"][0]["entry_id"]
+            self.assertRegex(first_id, r"^cand-\d{8}T\d{6}Z-inst[0-9a-f]{8}-[0-9a-f]{6}$")
+            self.assertEqual(second["apply_summary"]["created_candidate_count"], 0)
+            self.assertTrue(
+                any("Candidate content hash already exists" in item["reason"] for item in second["apply_summary"]["skipped_actions"])
+            )
+
     def test_apply_mode_creates_low_confidence_seed_candidate_from_complete_single_observation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = Path(tmp_dir)

--- a/tests/test_kb_desktop_ui.py
+++ b/tests/test_kb_desktop_ui.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
 from pathlib import Path
 
-from local_kb.desktop_app import _card_type_value, _detail_paragraphs
-from local_kb.store import resolve_repo_root
+from local_kb.desktop_app import (
+    _card_type_value,
+    _detail_paragraphs,
+    _maintenance_display,
+    _maintenance_from_display,
+    _mode_display,
+    _mode_from_display,
+    _skill_badge_label,
+    _source_line,
+    _source_filter_label,
+    _status_filter_label,
+    _type_filter_label,
+    _wheel_scroll_units,
+)
+from local_kb.settings import ORGANIZATION_MODE, PERSONAL_MODE
+from local_kb.i18n import ZH_CN
+from local_kb.store import resolve_repo_root, write_yaml_file
 from local_kb.ui_data import (
     build_card_detail_payload,
     build_overview_payload,
@@ -44,6 +60,10 @@ class KbDesktopUiDataTests(unittest.TestCase):
         self.assertIsNotNone(payload)
         assert payload is not None
         self.assertEqual(payload["id"], "model-004")
+        self.assertEqual(payload["source_info"]["label"], "local/public")
+        self.assertEqual(payload["source_label"], "local/public")
+        self.assertEqual(payload["author_label"], "local")
+        self.assertFalse(payload["read_only"])
         self.assertIn("if", payload)
         self.assertIn("action", payload)
         self.assertIn("predict", payload)
@@ -61,6 +81,7 @@ class KbDesktopUiDataTests(unittest.TestCase):
         self.assertGreater(len(payload["results"]), 0)
         self.assertIn("id", payload["results"][0])
         self.assertIn("route_reason", payload["results"][0])
+        self.assertIn("source_info", payload["results"][0])
 
     def test_search_payload_filters_confidence_only_matches(self) -> None:
         payload = build_search_payload(self.repo_root, query="zzznomatchtoken", route_hint="")
@@ -85,6 +106,94 @@ class KbDesktopUiDataTests(unittest.TestCase):
         self.assertTrue(all(_card_type_value(item) == "model" for item in models))
         self.assertTrue(all(_card_type_value(item) == "preference" for item in preferences))
         self.assertFalse({item["id"] for item in models} & {item["id"] for item in preferences})
+
+    def test_card_summaries_expose_skill_dependency_badge_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(
+                root / "kb" / "public" / "skill-backed.yaml",
+                {
+                    "id": "skill-backed",
+                    "title": "Skill backed card",
+                    "type": "model",
+                    "scope": "public",
+                    "status": "trusted",
+                    "confidence": 0.9,
+                    "domain_path": ["shared"],
+                    "tags": ["skill"],
+                    "trigger_keywords": ["skill"],
+                    "required_skills": ["release-helper"],
+                    "recommended_skills": ["review-helper"],
+                    "if": {"notes": "A card uses Skills."},
+                    "action": {"description": "Show a small Skill badge on the cover."},
+                    "predict": {"expected_result": "The card is visibly Skill-backed."},
+                    "use": {"guidance": "Open detail for the exact dependency list."},
+                },
+            )
+
+            payload = build_route_view_payload(root, route="")
+            card = payload["deck"][0]
+
+        self.assertEqual(card["skill_dependency_count"], 2)
+        self.assertEqual(_skill_badge_label(card), "2 Skills")
+        self.assertEqual(_skill_badge_label(card, ZH_CN), "2 个技能")
+        self.assertEqual(_skill_badge_label({"skill_dependency_count": 1}), "1 Skill")
+        self.assertEqual(_skill_badge_label({"skill_dependency_count": 1}, ZH_CN), "1 个技能")
+
+    def test_sidebar_filter_labels_cover_all_statuses_and_types(self) -> None:
+        self.assertEqual(_status_filter_label("trusted"), "Trusted")
+        self.assertEqual(_status_filter_label("candidate"), "Candidates")
+        self.assertEqual(_status_filter_label("deprecated", ZH_CN), "已废弃")
+        self.assertEqual(_type_filter_label("model"), "Models")
+        self.assertEqual(_type_filter_label("preference"), "Preferences")
+        self.assertEqual(_type_filter_label("heuristic", ZH_CN), "启发式")
+        self.assertEqual(_type_filter_label("fact", ZH_CN), "事实")
+        self.assertEqual(_source_filter_label("local"), "Local")
+        self.assertEqual(_source_filter_label("organization", ZH_CN), "组织")
+
+    def test_source_line_uses_localized_compact_display_labels(self) -> None:
+        local_card = {
+            "scope": "public",
+            "source_label": "local/public",
+            "author_label": "local",
+            "source_info": {"kind": "local", "scope": "public"},
+        }
+        candidate_card = {
+            "scope": "private",
+            "source_label": "local/candidate",
+            "author_label": "local",
+            "source_info": {"kind": "local", "scope": "candidate"},
+        }
+        organization_card = {
+            "scope": "public",
+            "source_label": "org/sandbox/trusted",
+            "author_label": "sandbox",
+            "read_only": True,
+            "source_info": {"kind": "organization", "scope": "trusted", "organization_id": "sandbox"},
+        }
+
+        self.assertEqual(_source_line(local_card), "Local · Public · Author: This device")
+        self.assertEqual(_source_line(local_card, ZH_CN), "本地 · 公开 · 作者：本机")
+        self.assertEqual(_source_line(candidate_card, ZH_CN), "本地 · 候选 · 作者：本机")
+        self.assertEqual(_source_line(organization_card, ZH_CN), "组织 sandbox · 已信任 · 作者：未注明 · 只读")
+
+    def test_settings_combobox_display_values_roundtrip(self) -> None:
+        self.assertEqual(_mode_display(PERSONAL_MODE, ZH_CN), "个人")
+        self.assertEqual(_mode_display(ORGANIZATION_MODE), "Organization")
+        self.assertEqual(_mode_from_display("组织", ZH_CN), ORGANIZATION_MODE)
+        self.assertEqual(_mode_from_display("Personal", ZH_CN), PERSONAL_MODE)
+        self.assertEqual(_maintenance_display(True, ZH_CN), "参与组织维护")
+        self.assertEqual(_maintenance_display(False), "Do not participate")
+        self.assertTrue(_maintenance_from_display("Participate"))
+        self.assertFalse(_maintenance_from_display("不参与组织维护", ZH_CN))
+
+    def test_mousewheel_units_allow_faster_main_card_scrolling(self) -> None:
+        self.assertEqual(_wheel_scroll_units(120), -1)
+        self.assertEqual(_wheel_scroll_units(-120), 1)
+        self.assertEqual(_wheel_scroll_units(120, multiplier=3), -3)
+        self.assertEqual(_wheel_scroll_units(-240, multiplier=3), 6)
+        self.assertEqual(_wheel_scroll_units(40, multiplier=3), -1)
+        self.assertEqual(_wheel_scroll_units(0, multiplier=3), 0)
 
     def test_detail_paragraphs_hide_internal_schema_keys(self) -> None:
         paragraphs = _detail_paragraphs(

--- a/tests/test_kb_i18n.py
+++ b/tests/test_kb_i18n.py
@@ -190,7 +190,18 @@ class KbI18nTests(unittest.TestCase):
         card = {"id": "runtime-card", "title": "Codex 运行时工具环境中的对照式路线经验"}
 
         self.assertEqual(_cover_title(card, "zh-CN"), "Codex 运行时工具环境中的对照式路线经验")
-        self.assertEqual(_cover_title({"title": "Codex runtime behavior model"}, "en"), "Runtime Behavior")
+        self.assertEqual(_cover_title({"title": "Codex runtime behavior model"}, "en"), "Codex runtime behavior model")
+
+    def test_english_card_cover_keeps_full_localized_title(self) -> None:
+        card = {
+            "id": "model-004",
+            "title": "Repository tasks surface more prior models when the local KB is scanned first",
+        }
+
+        self.assertEqual(
+            _cover_title(card, "en"),
+            "Repository tasks surface more prior models when the local KB is scanned first",
+        )
 
     def test_language_selector_labels_are_bilingual_and_roundtrip(self) -> None:
         self.assertEqual(_language_display("en"), "English / 英文")

--- a/tests/test_multi_source_search.py
+++ b/tests/test_multi_source_search.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.search import render_search_payload, search_multi_source_entries
+from local_kb.store import write_yaml_file
+from local_kb.ui_data import (
+    build_card_detail_payload,
+    build_route_view_payload,
+    build_search_payload,
+    build_skill_registry_payload,
+    build_source_view_payload,
+)
+
+
+class MultiSourceSearchTests(unittest.TestCase):
+    def _write_card(self, path: Path, entry_id: str, title: str, route: list[str]) -> None:
+        write_yaml_file(
+            path,
+            {
+                "id": entry_id,
+                "title": title,
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.9,
+                "domain_path": route,
+                "tags": ["shared", "organization"],
+                "trigger_keywords": ["shared", "organization"],
+                "required_skills": ["demo-skill"],
+                "if": {"notes": "Shared search test scenario."},
+                "action": {"description": "Use the shared test card."},
+                "predict": {"expected_result": "The shared test card is found."},
+                "use": {"guidance": "Use this card for multi-source search tests."},
+            },
+        )
+
+    def test_multi_source_search_keeps_local_results_before_organization_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(root / "kb" / "public" / "local.yaml", "local-card", "Local shared card", ["shared"])
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+
+            results = search_multi_source_entries(
+                root,
+                query="shared organization",
+                path_hint="shared",
+                top_k=5,
+                organization_sources=[{"path": str(org), "organization_id": "sandbox", "repo_url": "https://example.invalid/org.git"}],
+            )
+            payload = render_search_payload(results, root)
+
+        self.assertEqual([item["id"] for item in payload], ["local-card", "org-card"])
+        self.assertEqual(payload[0]["source_info"]["label"], "local/public")
+        self.assertEqual(payload[0]["source_label"], "local/public")
+        self.assertEqual(payload[1]["source_info"]["label"], "org/sandbox/trusted")
+        self.assertEqual(payload[1]["source_label"], "org/sandbox/trusted")
+        self.assertEqual(payload[1]["author_label"], "sandbox")
+        self.assertTrue(payload[1]["source_info"]["read_only"])
+        self.assertTrue(payload[1]["read_only"])
+
+    def test_ui_search_payload_can_include_organization_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+
+            payload = build_search_payload(
+                root,
+                query="shared organization",
+                route_hint="shared",
+                organization_sources=[{"path": str(org), "organization_id": "sandbox"}],
+            )
+
+        self.assertEqual(payload["results"][0]["id"], "org-card")
+        self.assertEqual(payload["results"][0]["source_info"]["kind"], "organization")
+
+    def test_route_and_source_views_include_organization_sources_when_connected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(root / "kb" / "public" / "local.yaml", "local-card", "Local shared card", ["shared"])
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+
+            route_payload = build_route_view_payload(root, route="shared", organization_sources=sources)
+            local_payload = build_source_view_payload(root, "local", organization_sources=sources)
+            organization_payload = build_source_view_payload(root, "organization", organization_sources=sources)
+
+        self.assertEqual([item["id"] for item in route_payload["deck"]], ["local-card", "org-card"])
+        self.assertEqual([item["id"] for item in local_payload["deck"]], ["local-card"])
+        self.assertEqual([item["id"] for item in organization_payload["deck"]], ["org-card"])
+
+    def test_card_detail_payload_can_resolve_organization_search_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+            search_payload = build_search_payload(
+                root,
+                query="shared organization",
+                route_hint="shared",
+                organization_sources=[{"path": str(org), "organization_id": "sandbox"}],
+            )
+
+            detail = build_card_detail_payload(
+                root,
+                "org-card",
+                organization_sources=[{"path": str(org), "organization_id": "sandbox"}],
+                source_info=search_payload["results"][0]["source_info"],
+            )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail["id"], "org-card")
+        self.assertEqual(detail["source_label"], "org/sandbox/trusted")
+        self.assertTrue(detail["read_only"])
+        self.assertEqual(detail["recent_history"], [])
+
+    def test_card_detail_payload_prefers_organization_source_info_over_same_id_local_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(root / "kb" / "candidates" / "adopted" / "sandbox" / "org-card.yaml", "org-card", "Local adopted copy", ["shared"])
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+            search_payload = build_search_payload(
+                root,
+                query="shared organization",
+                route_hint="shared",
+                organization_sources=[{"path": str(org), "organization_id": "sandbox"}],
+            )
+            organization_summary = next(
+                item for item in search_payload["results"] if item["source_info"]["kind"] == "organization"
+            )
+
+            detail = build_card_detail_payload(
+                root,
+                "org-card",
+                organization_sources=[{"path": str(org), "organization_id": "sandbox"}],
+                source_info=organization_summary["source_info"],
+            )
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail["title"], "Organization shared card")
+        self.assertEqual(detail["source_info"]["kind"], "organization")
+        self.assertEqual(detail["source_label"], "org/sandbox/trusted")
+        self.assertTrue(detail["read_only"])
+
+    def test_card_detail_payload_annotates_organization_skill_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_card(org / "kb" / "trusted" / "org.yaml", "org-card", "Organization shared card", ["shared"])
+            write_yaml_file(
+                org / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {
+                            "id": "demo-skill",
+                            "status": "approved",
+                            "version": "1.0.0",
+                            "source_repo": "https://example.invalid/skills.git",
+                            "content_hash": "sha256:" + "a" * 64,
+                        }
+                    ]
+                },
+            )
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+
+            detail = build_card_detail_payload(
+                root,
+                "org-card",
+                organization_sources=sources,
+                local_policy_allows_skill_auto_install=True,
+            )
+            registry = build_skill_registry_payload(sources, local_policy_allows_auto_install=True)
+
+        self.assertIsNotNone(detail)
+        assert detail is not None
+        self.assertEqual(detail["skill_dependencies"][0]["registry_status"], "approved")
+        self.assertTrue(detail["skill_dependencies"][0]["auto_install"]["eligible"])
+        self.assertEqual(registry["counts"]["approved"], 1)
+        self.assertTrue(registry["skills"][0]["auto_install"]["eligible"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_automation.py
+++ b/tests/test_org_automation.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_automation import run_organization_contribution, run_organization_maintenance
+from local_kb.settings import ORGANIZATION_MODE, save_desktop_settings
+from local_kb.store import write_yaml_file
+
+
+class OrganizationAutomationTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "trusted.yaml", {"id": "trusted", "status": "trusted"})
+        write_yaml_file(root / "kb" / "candidates" / "candidate.yaml", {"id": "candidate", "status": "candidate"})
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": [{"id": "org.demo", "status": "approved"}]})
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def _write_local_card(self, root: Path, entry_id: str = "share-model") -> None:
+        write_yaml_file(
+            root / "kb" / "public" / f"{entry_id}.yaml",
+            {
+                "id": entry_id,
+                "title": "Shareable model",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.82,
+                "domain_path": ["system", "knowledge-library", "organization"],
+                "tags": ["organization", "sharing"],
+                "trigger_keywords": ["organization", "outbox"],
+                "if": {"notes": "A reusable organization KB contribution is useful."},
+                "action": {"description": "Export it through the organization outbox."},
+                "predict": {"expected_result": "Other machines can reuse the model."},
+                "use": {"guidance": "Keep private details out of the shared proposal."},
+            },
+        )
+
+    def _save_organization_settings(
+        self,
+        repo_root: Path,
+        org_root: Path,
+        *,
+        maintenance_requested: bool = False,
+    ) -> None:
+        save_desktop_settings(
+            repo_root,
+            {
+                "mode": ORGANIZATION_MODE,
+                "organization": {
+                    "repo_url": str(org_root),
+                    "local_mirror_path": str(org_root),
+                    "organization_id": "sandbox",
+                    "validated": True,
+                    "validation_status": "valid",
+                    "organization_maintenance_requested": maintenance_requested,
+                },
+            },
+        )
+
+    def test_contribution_noops_without_valid_organization_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_organization_contribution(Path(tmp), record_postflight=False)
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["skipped"], result)
+        self.assertFalse(result["settings_gate"]["available"])
+        self.assertEqual(result["preflight"], {})
+        self.assertFalse(result["postflight_recorded"])
+
+    def test_automation_scripts_noop_successfully_without_settings(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmp:
+            local_root = Path(tmp)
+            outbox = subprocess.run(
+                [
+                    sys.executable,
+                    str(repo_root / "scripts" / "kb_org_outbox.py"),
+                    "--repo-root",
+                    str(local_root),
+                    "--automation",
+                    "--no-postflight",
+                ],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            maintainer = subprocess.run(
+                [
+                    sys.executable,
+                    str(repo_root / "scripts" / "kb_org_maintainer.py"),
+                    "--repo-root",
+                    str(local_root),
+                    "--automation",
+                    "--no-postflight",
+                ],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(outbox.returncode, 0, outbox.stderr)
+        self.assertEqual(maintainer.returncode, 0, maintainer.stderr)
+        self.assertTrue(json.loads(outbox.stdout)["skipped"])
+        self.assertTrue(json.loads(maintainer.stdout)["skipped"])
+
+    def test_contribution_dry_run_uses_valid_settings_and_hash_gated_outbox(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            repo = root / "repo"
+            self._write_org_repo(org)
+            self._write_local_card(repo)
+            self._save_organization_settings(repo, org)
+
+            result = run_organization_contribution(repo, dry_run=True, record_postflight=False)
+
+        self.assertTrue(result["ok"], result)
+        self.assertFalse(result["skipped"], result)
+        self.assertTrue(result["settings_gate"]["available"])
+        self.assertEqual(result["organization_id"], "sandbox")
+        self.assertEqual(result["outbox"]["created_count"], 1)
+        self.assertEqual(result["outbox"]["skipped_count"], 0)
+        self.assertFalse((repo / "kb" / "outbox").exists())
+        self.assertFalse(result["postflight_recorded"])
+
+    def test_maintenance_noops_until_participation_is_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            repo = root / "repo"
+            self._write_org_repo(org)
+            self._save_organization_settings(repo, org, maintenance_requested=False)
+
+            result = run_organization_maintenance(repo, record_postflight=False)
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["skipped"], result)
+        self.assertFalse(result["settings_gate"]["available"])
+        self.assertFalse(result["participation"]["available"])
+
+    def test_maintenance_runs_when_participation_is_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            repo = root / "repo"
+            self._write_org_repo(org)
+            self._save_organization_settings(repo, org, maintenance_requested=True)
+            skill_dir = repo / ".agents" / "skills" / "organization-review"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: organization-review\ndescription: Review organization KB proposals.\n---\n",
+                encoding="utf-8",
+            )
+
+            result = run_organization_maintenance(repo, record_postflight=False)
+
+        self.assertTrue(result["ok"], result)
+        self.assertFalse(result["skipped"], result)
+        self.assertTrue(result["settings_gate"]["available"])
+        self.assertTrue(result["participation"]["available"])
+        self.assertEqual(result["organization_id"], "sandbox")
+        self.assertEqual(result["report"]["candidate_count"], 1)
+        self.assertTrue(result["report"]["organization_review_skill"]["installed"])
+        self.assertIn("review-organization-candidates", result["report"]["recommendations"])
+        self.assertFalse(result["postflight_recorded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_checks.py
+++ b/tests/test_org_checks.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_checks import check_organization_repository
+from local_kb.store import write_yaml_file
+
+
+class OrganizationChecksTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "trusted.yaml", {"id": "trusted-card", "status": "trusted"})
+        write_yaml_file(root / "kb" / "candidates" / "candidate.yaml", {"id": "candidate-card", "status": "candidate"})
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(
+            root / "skills" / "registry.yaml",
+            {
+                "skills": [
+                    {
+                        "id": "approved-skill",
+                        "status": "approved",
+                        "version": "1.0.0",
+                        "content_hash": "sha256:" + "a" * 64,
+                    },
+                    {"id": "candidate-skill", "status": "candidate"},
+                    {"id": "rejected-skill", "status": "rejected"},
+                ]
+            },
+        )
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def test_low_risk_candidate_change_is_auto_merge_eligible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+
+            result = check_organization_repository(
+                root,
+                changed_files=["kb/candidates/candidate.yaml"],
+                enforce_low_risk=True,
+            )
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["auto_merge_eligible"], result)
+
+    def test_protected_trusted_change_blocks_low_risk_auto_merge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+
+            result = check_organization_repository(
+                root,
+                changed_files=["kb/trusted/trusted.yaml"],
+                enforce_low_risk=True,
+            )
+
+        self.assertFalse(result["ok"], result)
+        self.assertFalse(result["auto_merge_eligible"])
+        self.assertIn("path is not eligible for low-risk auto-merge: kb/trusted/trusted.yaml", result["errors"])
+
+    def test_rejects_unpinned_approved_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            write_yaml_file(root / "skills" / "registry.yaml", {"skills": [{"id": "bad", "status": "approved"}]})
+
+            result = check_organization_repository(root, changed_files=["skills/registry.yaml"])
+
+        self.assertFalse(result["ok"], result)
+        self.assertIn("skills/registry.yaml: approved skill bad must pin version", result["errors"])
+        self.assertIn("skills/registry.yaml: approved skill bad must pin sha256 content_hash", result["errors"])
+
+    def test_repeated_skill_id_is_allowed_when_bundle_versions_are_pinned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            write_yaml_file(
+                root / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {
+                            "id": "demo-skill",
+                            "bundle_id": "bundle-a",
+                            "status": "approved",
+                            "version_time": "2026-04-24T10:00:00Z",
+                            "content_hash": "sha256:" + "1" * 64,
+                        },
+                        {
+                            "id": "demo-skill",
+                            "bundle_id": "bundle-b",
+                            "status": "approved",
+                            "version_time": "2026-04-24T11:00:00Z",
+                            "content_hash": "sha256:" + "2" * 64,
+                        },
+                    ]
+                },
+            )
+
+            result = check_organization_repository(root, changed_files=["skills/registry.yaml"])
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(any("duplicate skill id handle" in warning for warning in result["warnings"]))
+
+    def test_rejects_secret_and_local_path_patterns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            write_yaml_file(
+                root / "kb" / "imports" / "alice" / "leaky.yaml",
+                {
+                    "id": "leaky",
+                    "status": "candidate",
+                    "note": "C:\\Users\\alice\\.codex\\token",
+                    "api_key": "sk-" + "a" * 32,
+                },
+            )
+
+            result = check_organization_repository(root, changed_files=["kb/imports/alice/leaky.yaml"])
+
+        self.assertFalse(result["ok"], result)
+        self.assertTrue(any("possible secret" in error for error in result["errors"]), result["errors"])
+        self.assertTrue(any("local machine path" in error for error in result["errors"]), result["errors"])
+
+    def test_reports_duplicate_card_content_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            card = {
+                "id": "first",
+                "title": "Shared duplicate",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "domain_path": ["shared"],
+                "if": {"notes": "Same content."},
+                "action": {"description": "Use same content."},
+                "predict": {"expected_result": "Duplicate is detected."},
+                "use": {"guidance": "Do not keep exact duplicate payloads."},
+            }
+            duplicate = dict(card)
+            duplicate["id"] = "second"
+            duplicate["status"] = "candidate"
+            write_yaml_file(root / "kb" / "trusted" / "first.yaml", card)
+            write_yaml_file(root / "kb" / "imports" / "alice" / "second.yaml", duplicate)
+
+            result = check_organization_repository(root)
+
+        duplicate_hashes = result["checks"]["cards"]["duplicate_content_hashes"]
+        self.assertTrue(duplicate_hashes, result)
+        self.assertTrue(any("duplicate card content hash" in warning for warning in result["warnings"]))
+
+    def test_duplicate_card_content_hash_blocks_low_risk_auto_merge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            card = {
+                "id": "first",
+                "title": "Shared duplicate",
+                "type": "model",
+                "scope": "public",
+                "status": "candidate",
+                "domain_path": ["shared"],
+                "if": {"notes": "Same content."},
+                "action": {"description": "Use same content."},
+                "predict": {"expected_result": "Duplicate is detected."},
+                "use": {"guidance": "Do not keep exact duplicate payloads."},
+            }
+            duplicate = dict(card)
+            duplicate["id"] = "second"
+            write_yaml_file(root / "kb" / "imports" / "alice" / "first.yaml", card)
+            write_yaml_file(root / "kb" / "imports" / "alice" / "second.yaml", duplicate)
+
+            result = check_organization_repository(
+                root,
+                changed_files=["kb/imports/alice/first.yaml", "kb/imports/alice/second.yaml"],
+                enforce_low_risk=True,
+            )
+
+        self.assertFalse(result["ok"], result)
+        self.assertIn("duplicate card content hashes require organization maintenance", result["errors"])
+
+    def test_cli_outputs_json_and_exits_nonzero_on_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            write_yaml_file(root / "skills" / "registry.yaml", {"skills": [{"id": "bad", "status": "blocked"}]})
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/kb_org_check.py",
+                    "--org-root",
+                    str(root),
+                    "--changed-file",
+                    "skills/registry.yaml",
+                ],
+                cwd=Path(__file__).resolve().parents[1],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(completed.stdout)
+
+        self.assertEqual(completed.returncode, 2)
+        self.assertFalse(payload["ok"])
+        self.assertIn("skills/registry.yaml: skill bad has invalid status: blocked", payload["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_cleanup.py
+++ b/tests/test_org_cleanup.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_checks import check_organization_repository
+from local_kb.org_cleanup import apply_organization_cleanup_proposal, build_organization_cleanup_proposal
+from local_kb.store import load_yaml_file, write_yaml_file
+from local_kb.ui_data import build_search_payload
+from tests.org_helpers import base_card, write_valid_org_repo
+
+
+class OrganizationCleanupTests(unittest.TestCase):
+    def _write_cleanup_repo(self, root: Path) -> None:
+        write_valid_org_repo(root, include_sandbox_cards=False)
+        trusted_low = base_card(
+            "trusted-low",
+            "Old trusted route",
+            "This trusted card has weak evidence and should be scored down.",
+            status="trusted",
+            confidence=0.4,
+        )
+        duplicate_a = base_card(
+            "duplicate-a",
+            "Duplicate candidate",
+            "Keep only one copy of this organization candidate.",
+            status="candidate",
+            confidence=0.7,
+        )
+        duplicate_b = dict(duplicate_a)
+        duplicate_b["id"] = "duplicate-b"
+        weak = base_card(
+            "weak-card",
+            "Random weak candidate",
+            "Random unreviewed text without durable organization value.",
+            status="candidate",
+            confidence=0.2,
+        )
+        strong = base_card(
+            "strong-card",
+            "Strong candidate",
+            "Strong evidence should produce a promotion proposal, not direct low-risk apply.",
+            status="candidate",
+            confidence=0.9,
+        )
+        stale = base_card(
+            "stale-rejected",
+            "Stale rejected card",
+            "Already rejected and low value.",
+            status="rejected",
+            confidence=0.1,
+        )
+        similar = base_card(
+            "similar-card",
+            "Duplicate candidate",
+            "A similar but not identical candidate should trigger merge review.",
+            status="candidate",
+            confidence=0.72,
+        )
+        write_yaml_file(root / "kb" / "trusted" / "trusted-low.yaml", trusted_low)
+        write_yaml_file(root / "kb" / "candidates" / "duplicate-a.yaml", duplicate_a)
+        write_yaml_file(root / "kb" / "candidates" / "duplicate-b.yaml", duplicate_b)
+        write_yaml_file(root / "kb" / "candidates" / "weak-card.yaml", weak)
+        write_yaml_file(root / "kb" / "candidates" / "strong-card.yaml", strong)
+        write_yaml_file(root / "kb" / "candidates" / "stale-rejected.yaml", stale)
+        write_yaml_file(root / "kb" / "candidates" / "similar-card.yaml", similar)
+
+    def test_cleanup_proposal_includes_duplicates_weak_cards_score_adjustments_and_review_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_cleanup_repo(root)
+
+            proposal = build_organization_cleanup_proposal(root)
+            action_types = [item["action_type"] for item in proposal["actions"]]
+
+        self.assertTrue(proposal["ok"], proposal)
+        self.assertIn("mark-duplicate", action_types)
+        self.assertIn("status-adjust", action_types)
+        self.assertIn("confidence-adjust", action_types)
+        self.assertIn("delete-card", action_types)
+        self.assertIn("merge-cards", action_types)
+        promotion = next(item for item in proposal["actions"] if item.get("entry_id") == "strong-card")
+        self.assertEqual(promotion["proposed_status"], "trusted")
+        self.assertFalse(promotion["apply_supported"])
+
+    def test_cleanup_apply_updates_low_risk_actions_audits_and_keeps_checks_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_cleanup_repo(root)
+            proposal = build_organization_cleanup_proposal(root)
+
+            result = apply_organization_cleanup_proposal(
+                root,
+                proposal,
+                allow_actions={"confidence-adjust", "status-adjust", "mark-duplicate", "delete-card"},
+                allow_trusted=True,
+                allow_delete=True,
+            )
+            weak = load_yaml_file(root / "kb" / "candidates" / "weak-card.yaml")
+            duplicate_b = load_yaml_file(root / "kb" / "candidates" / "duplicate-b.yaml")
+            trusted_low = load_yaml_file(root / "kb" / "trusted" / "trusted-low.yaml")
+            strong = load_yaml_file(root / "kb" / "candidates" / "strong-card.yaml")
+            stale_exists = (root / "kb" / "candidates" / "stale-rejected.yaml").exists()
+            check = check_organization_repository(root)
+            rejected_search = build_search_payload(root, "Random weak candidate", organization_sources=[{"path": str(root), "organization_id": "sandbox"}])
+            rejected_result_ids = [item["id"] for item in rejected_search["results"]]
+            audit_exists = (root / "maintenance" / "cleanup_audit.jsonl").exists()
+
+        self.assertTrue(result["ok"], result)
+        self.assertGreaterEqual(result["applied_count"], 4)
+        self.assertEqual(weak["status"], "rejected")
+        self.assertEqual(duplicate_b["status"], "rejected")
+        self.assertEqual(duplicate_b["organization_cleanup"]["duplicate_of"], "kb/candidates/duplicate-a.yaml")
+        self.assertLess(trusted_low["confidence"], 0.4)
+        self.assertEqual(strong["status"], "candidate")
+        self.assertFalse(stale_exists)
+        self.assertTrue(check["ok"], check)
+        self.assertNotIn("weak-card", rejected_result_ids)
+        self.assertTrue(audit_exists)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_contribution.py
+++ b/tests/test_org_contribution.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_contribution import github_compare_url, prepare_organization_import_branch
+from local_kb.org_sources import _run_git
+from local_kb.store import write_yaml_file
+
+
+class OrganizationContributionTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "model.yaml", {"id": "trusted", "status": "trusted"})
+        (root / "kb" / "candidates").mkdir(parents=True)
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": []})
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def test_prepare_organization_import_branch_copies_outbox_to_imports_and_commits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            outbox = root / "outbox"
+            self._write_org_repo(org)
+            write_yaml_file(outbox / "proposal.yaml", {"id": "proposal", "status": "candidate"})
+            self.assertEqual(0, _run_git(["init"], cwd=org).returncode)
+            self.assertEqual(0, _run_git(["add", "."], cwd=org).returncode)
+            self.assertEqual(
+                0,
+                _run_git(
+                    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+                    cwd=org,
+                ).returncode,
+            )
+
+            result = prepare_organization_import_branch(
+                org,
+                outbox,
+                contributor_id="alice/main-laptop",
+                branch_name="contrib/test/imports",
+            )
+            imported = org / "kb" / "imports" / "alice-main-laptop" / "proposal.yaml"
+            imported_exists = imported.exists()
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["branch"], "contrib/test/imports")
+        self.assertEqual(result["created_files"], ["kb/imports/alice-main-laptop/proposal.yaml"])
+        self.assertTrue(result["committed"])
+        self.assertTrue(result["commit"])
+        self.assertTrue(imported_exists)
+
+    def test_prepare_organization_import_branch_can_push_to_remote(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            remote = root / "remote.git"
+            org = root / "org"
+            outbox = root / "outbox"
+            self.assertEqual(0, _run_git(["init", "--bare", str(remote)]).returncode)
+            self._write_org_repo(org)
+            write_yaml_file(outbox / "proposal.yaml", {"id": "proposal", "status": "candidate"})
+            self.assertEqual(0, _run_git(["init"], cwd=org).returncode)
+            self.assertEqual(0, _run_git(["remote", "add", "origin", str(remote)], cwd=org).returncode)
+            self.assertEqual(0, _run_git(["add", "."], cwd=org).returncode)
+            self.assertEqual(
+                0,
+                _run_git(
+                    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+                    cwd=org,
+                ).returncode,
+            )
+            self.assertEqual(0, _run_git(["branch", "-M", "main"], cwd=org).returncode)
+            self.assertEqual(0, _run_git(["push", "-u", "origin", "main"], cwd=org).returncode)
+
+            result = prepare_organization_import_branch(
+                org,
+                outbox,
+                contributor_id="alice",
+                branch_name="contrib/alice/proposal",
+                push=True,
+            )
+            branches = _run_git(["branch", "--list"], cwd=remote)
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["push"]["pushed"], result)
+        self.assertIn("contrib/alice/proposal", branches.stdout)
+
+    def test_github_compare_url_supports_https_and_ssh_remotes(self) -> None:
+        self.assertEqual(
+            github_compare_url("https://github.com/example/org-kb.git", "contrib/alice/proposal"),
+            "https://github.com/example/org-kb/compare/main...contrib/alice/proposal?expand=1",
+        )
+        self.assertEqual(
+            github_compare_url("git@github.com:example/org-kb.git", "contrib/alice/proposal", base_branch="stable"),
+            "https://github.com/example/org-kb/compare/stable...contrib/alice/proposal?expand=1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_github_automation.py
+++ b/tests/test_org_github_automation.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_github_automation import install_github_automation_templates
+from local_kb.store import write_yaml_file
+
+
+class OrganizationGitHubAutomationTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "model.yaml", {"id": "model", "status": "trusted"})
+        (root / "kb" / "candidates").mkdir(parents=True)
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": []})
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def test_installs_github_workflow_templates_into_valid_org_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+
+            result = install_github_automation_templates(root)
+            checks = (root / ".github" / "workflows" / "org-kb-checks.yml").read_text(encoding="utf-8")
+            auto_merge = (root / ".github" / "workflows" / "org-kb-auto-merge.yml").read_text(encoding="utf-8")
+            script = (root / ".github" / "scripts" / "org_kb_check.py").read_text(encoding="utf-8")
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(
+            sorted(result["installed"]),
+            [
+                ".github/scripts/org_kb_check.py",
+                ".github/workflows/org-kb-auto-merge.yml",
+                ".github/workflows/org-kb-checks.yml",
+            ],
+        )
+        self.assertIn(".github/scripts/org_kb_check.py", checks)
+        self.assertIn("org-kb:auto-merge", auto_merge)
+        self.assertIn("SKILL_REVIEW_STATES", script)
+
+    def test_does_not_overwrite_existing_workflow_without_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_org_repo(root)
+            target = root / ".github" / "workflows" / "org-kb-checks.yml"
+            target.parent.mkdir(parents=True)
+            target.write_text("custom\n", encoding="utf-8")
+
+            result = install_github_automation_templates(root)
+            text = target.read_text(encoding="utf-8")
+
+        self.assertTrue(result["ok"], result)
+        self.assertIn(".github/workflows/org-kb-checks.yml", result["skipped"])
+        self.assertEqual(text, "custom\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_maintenance.py
+++ b/tests/test_org_maintenance.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_maintenance import build_organization_maintenance_report
+from local_kb.store import write_yaml_file
+
+
+class OrganizationMaintenanceTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "model.yaml", {"id": "shared-card", "status": "trusted"})
+        write_yaml_file(root / "kb" / "candidates" / "dupe.yaml", {"id": "shared-card", "status": "candidate"})
+        (root / "kb" / "imports").mkdir(parents=True)
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": [{"id": "demo-skill", "status": "approved"}]})
+        (root / "skills" / "candidates").mkdir(parents=True)
+
+    def test_maintenance_report_ignores_duplicate_ids_and_detects_candidates_skills_and_outbox(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            org = root / "org"
+            self._write_org_repo(org)
+            write_yaml_file(repo_root / "kb" / "outbox" / "organization" / "sandbox" / "proposal.yaml", {"id": "proposal"})
+
+            report = build_organization_maintenance_report(org, repo_root=repo_root)
+
+        self.assertTrue(report["ok"], report)
+        self.assertEqual(report["organization_id"], "sandbox")
+        self.assertEqual(report["outbox_count"], 1)
+        self.assertIn("review-organization-candidates", report["recommendations"])
+        self.assertNotIn("review-duplicate-entry-ids", report["recommendations"])
+        self.assertIn("review-local-outbox-proposals", report["recommendations"])
+        self.assertIn("review-skill-registry", report["recommendations"])
+        self.assertIn("install-organization-review-skill-before-full-maintenance", report["recommendations"])
+        self.assertFalse(report["organization_review_skill"]["installed"])
+
+    def test_maintenance_report_detects_installed_organization_review_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            org = root / "org"
+            self._write_org_repo(org)
+            skill_dir = repo_root / ".agents" / "skills" / "organization-review"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: organization-review\ndescription: Review organization KB proposals.\n---\n",
+                encoding="utf-8",
+            )
+
+            report = build_organization_maintenance_report(org, repo_root=repo_root)
+
+        self.assertTrue(report["ok"], report)
+        self.assertTrue(report["organization_review_skill"]["installed"])
+        self.assertNotIn("install-organization-review-skill-before-full-maintenance", report["recommendations"])
+
+    def test_maintenance_report_surfaces_duplicate_hash_cleanup_signal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            org = root / "org"
+            self._write_org_repo(org)
+            duplicate_card = {
+                "id": "duplicate-a",
+                "title": "Duplicate organization card",
+                "type": "model",
+                "scope": "public",
+                "status": "candidate",
+                "confidence": 0.7,
+                "domain_path": ["shared"],
+                "tags": ["duplicate"],
+                "trigger_keywords": ["duplicate"],
+                "if": {"notes": "Same reusable condition."},
+                "action": {"description": "Use the same action."},
+                "predict": {"expected_result": "Duplicate hash should be detected."},
+                "use": {"guidance": "Keep only one canonical version."},
+            }
+            second_duplicate = dict(duplicate_card)
+            second_duplicate["id"] = "duplicate-b"
+            write_yaml_file(org / "kb" / "imports" / "alice" / "duplicate-a.yaml", duplicate_card)
+            write_yaml_file(org / "kb" / "imports" / "bob" / "duplicate-b.yaml", second_duplicate)
+
+            report = build_organization_maintenance_report(org, repo_root=repo_root)
+
+        self.assertTrue(report["ok"], report)
+        self.assertEqual(report["cleanup"]["duplicate_content_hash_count"], 1)
+        self.assertIn("review-duplicate-card-content-hashes", report["recommendations"])
+        self.assertIn("duplicate card content hashes require organization maintenance", report["organization_check"]["auto_merge_blockers"])
+        self.assertEqual(report["cleanup"]["similar_card_merge_apply"], "planned")
+        self.assertEqual(report["cleanup"]["weak_card_rejection_apply"], "planned")
+        self.assertEqual(report["cleanup"]["skill_bundle_cleanup_apply"], "partial")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_multi_machine.py
+++ b/tests/test_org_multi_machine.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.adoption import ADOPTION_KEY, adopt_organization_entry_by_source_info
+from local_kb.org_checks import check_organization_repository
+from local_kb.org_contribution import prepare_organization_import_branch
+from local_kb.org_outbox import build_organization_outbox, organization_outbox_dir
+from local_kb.org_sources import _run_git, connect_organization_source
+from local_kb.store import load_yaml_file, write_yaml_file
+from local_kb.ui_data import build_search_payload
+
+
+class OrganizationMultiMachineTests(unittest.TestCase):
+    def _write_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(
+            root / "kb" / "trusted" / "org-card.yaml",
+            {
+                "id": "org-card",
+                "title": "Organization shared card",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.9,
+                "domain_path": ["shared"],
+                "tags": ["shared", "organization"],
+                "trigger_keywords": ["shared", "organization"],
+                "if": {"notes": "Shared org scenario."},
+                "action": {"description": "Use org card."},
+                "predict": {"expected_result": "Org card is available."},
+                "use": {"guidance": "Adopt before local maintenance."},
+            },
+        )
+        (root / "kb" / "candidates").mkdir(parents=True)
+        (root / "kb" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+        (root / "kb" / "imports").mkdir(parents=True)
+        (root / "kb" / "imports" / ".gitkeep").write_text("", encoding="utf-8")
+        write_yaml_file(
+            root / "skills" / "registry.yaml",
+            {
+                "skills": [
+                    {
+                        "id": "approved-skill",
+                        "status": "approved",
+                        "version": "1.0.0",
+                        "content_hash": "sha256:" + "a" * 64,
+                    }
+                ]
+            },
+        )
+        (root / "skills" / "candidates").mkdir(parents=True)
+        (root / "skills" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+
+    def _init_git_repo(self, root: Path) -> None:
+        self.assertEqual(0, _run_git(["init"], cwd=root).returncode)
+        self.assertEqual(0, _run_git(["add", "."], cwd=root).returncode)
+        self.assertEqual(
+            0,
+            _run_git(
+                ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+                cwd=root,
+            ).returncode,
+        )
+
+    def _source(self, connect_result: dict) -> dict:
+        settings = connect_result["settings"]
+        return {
+            "path": settings["local_mirror_path"],
+            "organization_id": settings["organization_id"],
+            "repo_url": "https://example.invalid/khaos-org-kb-sandbox.git",
+            "source_commit": settings["last_sync_commit"],
+        }
+
+    def test_two_local_profiles_share_org_repo_but_keep_adoption_feedback_separate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org_source = root / "org-source"
+            profile_a = root / "profile-a"
+            profile_b = root / "profile-b"
+            self._write_org_repo(org_source)
+            self._init_git_repo(org_source)
+
+            connect_a = connect_organization_source(profile_a, str(org_source))
+            connect_b = connect_organization_source(profile_b, str(org_source))
+            source_a = self._source(connect_a)
+            source_b = self._source(connect_b)
+            sources_a = [source_a]
+            sources_b = [source_b]
+
+            payload_a = build_search_payload(profile_a, "shared organization", organization_sources=sources_a)
+            payload_b = build_search_payload(profile_b, "shared organization", organization_sources=sources_b)
+            adoption_a = adopt_organization_entry_by_source_info(
+                profile_a,
+                "org-card",
+                sources_a,
+                source_info=payload_a["results"][0]["source_info"],
+            )
+            adoption_b = adopt_organization_entry_by_source_info(
+                profile_b,
+                "org-card",
+                sources_b,
+                source_info=payload_b["results"][0]["source_info"],
+            )
+
+            adopted_a = load_yaml_file(Path(adoption_a["path"]))
+            adopted_a["use"]["guidance"] = "Profile A refined this for organization feedback."
+            write_yaml_file(Path(adoption_a["path"]), adopted_a)
+
+            outbox_a = build_organization_outbox(profile_a, organization_id="sandbox")
+            outbox_b = build_organization_outbox(profile_b, organization_id="sandbox")
+            import_result = prepare_organization_import_branch(
+                Path(source_a["path"]),
+                organization_outbox_dir(profile_a, "sandbox"),
+                contributor_id="profile-a",
+                branch_name="contrib/profile-a/feedback",
+            )
+            check_result = check_organization_repository(
+                Path(source_a["path"]),
+                changed_files=import_result["created_files"],
+                enforce_low_risk=True,
+            )
+            adoption_b_hit_count = load_yaml_file(Path(adoption_b["path"]))[ADOPTION_KEY]["hit_count"]
+
+        self.assertTrue(connect_a["ok"], connect_a)
+        self.assertTrue(connect_b["ok"], connect_b)
+        self.assertNotEqual(source_a["path"], source_b["path"])
+        self.assertNotEqual(adoption_a["path"], adoption_b["path"])
+        self.assertEqual(adoption_b_hit_count, 1)
+        self.assertEqual(outbox_a["created_count"], 1, outbox_a)
+        self.assertEqual(outbox_a["created"][0]["proposal_kind"], "adopted-feedback")
+        self.assertEqual(outbox_b["created_count"], 0, outbox_b)
+        self.assertTrue(import_result["ok"], import_result)
+        self.assertEqual(len(import_result["created_files"]), 1)
+        self.assertRegex(
+            import_result["created_files"][0],
+            r"^kb/imports/profile-a/cand-\d{8}T\d{6}Z-inst[0-9a-f]{8}-[0-9a-f]{6}\.yaml$",
+        )
+        self.assertTrue(check_result["ok"], check_result)
+        self.assertTrue(check_result["auto_merge_eligible"], check_result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_outbox.py
+++ b/tests/test_org_outbox.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.adoption import ADOPTION_KEY, adoption_content_hash
+from local_kb.org_outbox import build_organization_outbox
+from local_kb.store import load_yaml_file, write_yaml_file
+
+
+class OrganizationOutboxTests(unittest.TestCase):
+    def _card(self, entry_id: str, card_type: str = "model", scope: str = "public") -> dict:
+        return {
+            "id": entry_id,
+            "title": f"{entry_id} title",
+            "type": card_type,
+            "scope": scope,
+            "status": "trusted",
+            "confidence": 0.8,
+            "domain_path": ["shared"],
+            "tags": ["shared"],
+            "trigger_keywords": ["shared"],
+            "if": {"notes": "Shareable scenario."},
+            "action": {"description": "Use card."},
+            "predict": {"expected_result": "Card helps."},
+            "use": {"guidance": "Share only when eligible."},
+        }
+
+    def _adopted_card(self, entry_id: str, *, diverged: bool = False) -> dict:
+        payload = self._card(entry_id)
+        source_hash = adoption_content_hash(payload)
+        payload[ADOPTION_KEY] = {
+            "organization_id": "sandbox",
+            "source_entry_id": entry_id,
+            "source_repo": "https://example.invalid/org.git",
+            "source_commit": "abc123",
+            "source_path": f"kb/trusted/{entry_id}.yaml",
+            "adopted_at": "2026-04-24T00:00:00Z",
+            "last_used_at": "2026-04-24T00:00:00Z",
+            "source_content_hash": source_hash,
+            "state": "clean",
+        }
+        if diverged:
+            payload["use"]["guidance"] = "Local improvement should become organization feedback."
+        return payload
+
+    def test_outbox_only_exports_shareable_cards_and_diverged_adoptions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(root / "kb" / "public" / "model.yaml", self._card("share-model"))
+            duplicate = self._card("share-model-duplicate")
+            duplicate["title"] = "share-model title"
+            write_yaml_file(root / "kb" / "public" / "z-model-copy.yaml", duplicate)
+            write_yaml_file(root / "kb" / "public" / "preference.yaml", self._card("skip-pref", card_type="preference"))
+            write_yaml_file(root / "kb" / "private" / "private.yaml", self._card("skip-private", scope="private"))
+            write_yaml_file(root / "kb" / "candidates" / "adopted" / "sandbox" / "clean.yaml", self._adopted_card("clean-adopted"))
+            write_yaml_file(
+                root / "kb" / "candidates" / "adopted" / "sandbox" / "diverged.yaml",
+                self._adopted_card("diverged-adopted", diverged=True),
+            )
+
+            result = build_organization_outbox(root, organization_id="sandbox")
+            created_ids = [item["entry_id"] for item in result["created"]]
+            outbox_files = sorted((root / "kb" / "outbox" / "organization" / "sandbox").glob("*.yaml"))
+            payloads = [load_yaml_file(path) for path in outbox_files]
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(created_ids, ["share-model", "diverged-adopted"])
+        self.assertEqual(len(payloads), 2)
+        self.assertTrue(all(payload["status"] == "candidate" for payload in payloads))
+        by_id = {payload["id"]: payload for payload in payloads}
+        self.assertEqual(by_id["diverged-adopted"]["organization_proposal"]["proposal_kind"], "adopted-feedback")
+        self.assertTrue(all(payload["organization_proposal"]["content_hash"] for payload in payloads))
+        skipped = {item["entry_id"]: item["reasons"] for item in result["skipped"]}
+        self.assertIn("duplicate content hash already exported", skipped["share-model-duplicate"])
+        self.assertIn("card type is not shareable", skipped["skip-pref"])
+        self.assertIn("card scope is not public", skipped["skip-private"])
+        self.assertIn("clean adopted organization card does not need feedback", skipped["clean-adopted"])
+
+    def test_outbox_dry_run_does_not_write_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(root / "kb" / "public" / "model.yaml", self._card("share-model"))
+
+            result = build_organization_outbox(root, organization_id="sandbox", dry_run=True)
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["created_count"], 1)
+            self.assertFalse((root / "kb" / "outbox").exists())
+
+    def test_outbox_skips_hashes_already_exported_or_present_in_organization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            write_yaml_file(root / "kb" / "public" / "model.yaml", self._card("share-model"))
+            write_yaml_file(org / "kb" / "trusted" / "existing.yaml", self._card("existing-org"))
+            write_yaml_file(org / "kb" / "imports" / "alice" / "existing-import.yaml", self._card("existing-import"))
+            local_duplicate = self._card("local-duplicate")
+            local_duplicate["title"] = "existing-org title"
+            write_yaml_file(root / "kb" / "public" / "local-duplicate.yaml", local_duplicate)
+            import_duplicate = self._card("import-duplicate")
+            import_duplicate["title"] = "existing-import title"
+            write_yaml_file(root / "kb" / "public" / "import-duplicate.yaml", import_duplicate)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+
+            first = build_organization_outbox(root, organization_id="sandbox", organization_sources=sources)
+            second = build_organization_outbox(root, organization_id="sandbox", organization_sources=sources)
+
+        self.assertEqual([item["entry_id"] for item in first["created"]], ["share-model"])
+        first_skipped = {item["entry_id"]: item["reasons"] for item in first["skipped"]}
+        self.assertIn("content hash already exists in organization repository", first_skipped["local-duplicate"])
+        self.assertIn("content hash already exists in organization repository", first_skipped["import-duplicate"])
+        self.assertEqual(second["created_count"], 0)
+        second_skipped = {item["entry_id"]: item["reasons"] for item in second["skipped"]}
+        self.assertIn("content hash was already exported from this installation", second_skipped["share-model"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_org_sources.py
+++ b/tests/test_org_sources.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_sources import (
+    _run_git,
+    clone_or_fetch_organization_repo,
+    connect_organization_source,
+    default_org_mirror_path,
+    guess_organization_source_id,
+    validate_organization_repo,
+)
+from local_kb.store import write_yaml_file
+
+
+class OrganizationSourceTests(unittest.TestCase):
+    def _write_valid_org_repo(self, root: Path) -> None:
+        write_yaml_file(
+            root / "khaos_org_kb.yaml",
+            {
+                "kind": "khaos-organization-kb",
+                "schema_version": 1,
+                "organization_id": "sandbox",
+                "kb": {
+                    "trusted_path": "kb/trusted",
+                    "candidates_path": "kb/candidates",
+                    "imports_path": "kb/imports",
+                },
+                "skills": {
+                    "registry_path": "skills/registry.yaml",
+                    "candidates_path": "skills/candidates",
+                },
+            },
+        )
+        write_yaml_file(root / "kb" / "trusted" / "model.yaml", {"id": "model", "status": "trusted"})
+        write_yaml_file(root / "kb" / "candidates" / "candidate.yaml", {"id": "candidate", "status": "candidate"})
+        (root / "kb" / "imports").mkdir(parents=True)
+        (root / "kb" / "imports" / ".gitkeep").write_text("", encoding="utf-8")
+        write_yaml_file(root / "skills" / "registry.yaml", {"skills": [{"id": "org.demo", "status": "approved"}]})
+        (root / "skills" / "candidates").mkdir(parents=True)
+        (root / "skills" / "candidates" / ".gitkeep").write_text("", encoding="utf-8")
+
+    def test_validate_organization_repo_accepts_valid_manifest_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_valid_org_repo(root)
+
+            result = validate_organization_repo(root)
+
+        self.assertTrue(result["ok"], result["errors"])
+        self.assertEqual(result["organization_id"], "sandbox")
+        self.assertEqual(result["trusted_count"], 1)
+        self.assertEqual(result["candidate_count"], 1)
+        self.assertEqual(result["skill_count"], 1)
+
+    def test_validate_organization_repo_rejects_missing_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = validate_organization_repo(Path(tmp))
+
+        self.assertFalse(result["ok"])
+        self.assertIn("missing organization KB manifest", result["errors"][0])
+
+    def test_default_org_mirror_path_sanitizes_organization_id(self) -> None:
+        path = default_org_mirror_path(Path("repo"), "acme/org kb")
+
+        self.assertEqual(path.as_posix(), "repo/.local/organization_sources/acme-org-kb")
+
+    def test_guess_organization_source_id_uses_repo_name(self) -> None:
+        self.assertEqual(
+            guess_organization_source_id("https://github.com/acme/khaos-org-kb-sandbox.git"),
+            "khaos-org-kb-sandbox",
+        )
+
+    def test_clone_or_fetch_supports_local_git_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            mirror = root / "mirror"
+            self._write_valid_org_repo(source)
+            self.assertEqual(0, _run_git(["init"], cwd=source).returncode)
+            self.assertEqual(0, _run_git(["add", "."], cwd=source).returncode)
+            self.assertEqual(
+                0,
+                _run_git(
+                    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+                    cwd=source,
+                ).returncode,
+            )
+
+            clone_result = clone_or_fetch_organization_repo(str(source), mirror)
+            validation = validate_organization_repo(mirror)
+
+        self.assertTrue(clone_result["ok"], clone_result["errors"])
+        self.assertEqual(clone_result["action"], "clone")
+        self.assertTrue(validation["ok"], validation["errors"])
+
+    def test_connect_organization_source_clones_valid_repo_and_builds_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            repo_root = root / "repo"
+            self._write_valid_org_repo(source)
+            self.assertEqual(0, _run_git(["init"], cwd=source).returncode)
+            self.assertEqual(0, _run_git(["add", "."], cwd=source).returncode)
+            self.assertEqual(
+                0,
+                _run_git(
+                    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"],
+                    cwd=source,
+                ).returncode,
+            )
+
+            result = connect_organization_source(repo_root, str(source))
+            mirror_exists = Path(result["settings"]["local_mirror_path"]).exists()
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["settings"]["validation_status"], "valid")
+        self.assertEqual(result["settings"]["organization_id"], "sandbox")
+        self.assertTrue(mirror_exists)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_organization_adoption.py
+++ b/tests/test_organization_adoption.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from local_kb.adoption import (
+    ADOPTION_KEY,
+    adopt_organization_entry_by_source_info,
+    adoption_state,
+    card_exchange_hash,
+)
+from local_kb.skill_sharing import skill_directory_content_hash
+from local_kb.search import render_search_payload, search_multi_source_entries
+from local_kb.store import load_yaml_file, write_yaml_file
+from local_kb.ui_data import build_search_payload
+
+
+class OrganizationAdoptionTests(unittest.TestCase):
+    def _write_org_card(self, org: Path) -> None:
+        write_yaml_file(
+            org / "kb" / "trusted" / "org-card.yaml",
+            {
+                "id": "org-card",
+                "title": "Organization shared card",
+                "type": "model",
+                "scope": "public",
+                "status": "trusted",
+                "confidence": 0.9,
+                "updated_at": date(2026, 4, 24),
+                "domain_path": ["shared"],
+                "tags": ["shared", "organization"],
+                "trigger_keywords": ["shared", "organization"],
+                "if": {"notes": "Shared org scenario."},
+                "action": {"description": "Use org card."},
+                "predict": {"expected_result": "Org card is available."},
+                "use": {"guidance": "Adopt before local maintenance."},
+            },
+        )
+
+    def test_organization_card_copy_on_use_creates_local_clean_adoption(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox", "repo_url": "https://example.invalid/org.git"}]
+            search_payload = build_search_payload(root, "shared organization", organization_sources=sources)
+
+            result = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=search_payload["results"][0]["source_info"],
+            )
+            adopted = load_yaml_file(Path(result["path"]))
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["created"])
+        self.assertRegex(adopted["id"], r"^cand-\d{8}T\d{6}Z-inst[0-9a-f]{8}-[0-9a-f]{6}$")
+        self.assertNotEqual(adopted["id"], "org-card")
+        self.assertEqual(adopted[ADOPTION_KEY]["organization_id"], "sandbox")
+        self.assertEqual(adopted[ADOPTION_KEY]["source_entry_id"], "org-card")
+        self.assertEqual(adopted[ADOPTION_KEY]["source_exchange_hash"], card_exchange_hash(adopted))
+        self.assertEqual(adoption_state(adopted), "clean")
+
+    def test_organization_card_use_reuses_existing_same_hash_local_card(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            local_payload = load_yaml_file(org / "kb" / "trusted" / "org-card.yaml")
+            local_payload["id"] = "local-card"
+            local_payload["i18n"] = {"zh-CN": {"title": "本地已有同内容卡"}}
+            write_yaml_file(root / "kb" / "public" / "local.yaml", local_payload)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+
+            result = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+            )
+            search_after = render_search_payload(
+                search_multi_source_entries(root, "shared organization", organization_sources=sources, top_k=5),
+                root,
+            )
+            adopted_path_exists = (root / "kb" / "candidates" / "adopted" / "sandbox" / "org-card.yaml").exists()
+
+        self.assertTrue(result["ok"], result)
+        self.assertFalse(result["created"])
+        self.assertTrue(result["matched_existing"])
+        self.assertEqual(result["entry_id"], "local-card")
+        self.assertFalse(adopted_path_exists)
+        self.assertEqual([item["id"] for item in search_after], ["local-card"])
+
+    def test_multi_source_search_hides_organization_card_after_local_adoption(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+            adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+
+            payload = render_search_payload(
+                search_multi_source_entries(root, "shared organization", organization_sources=sources, top_k=5),
+                root,
+            )
+
+        self.assertEqual([item["source_info"]["kind"] for item in payload], ["local"])
+        self.assertRegex(payload[0]["id"], r"^cand-\d{8}T\d{6}Z-inst[0-9a-f]{8}-[0-9a-f]{6}$")
+        self.assertEqual(payload[0]["source_info"]["scope"], "candidate")
+
+    def test_downloaded_hash_ledger_prevents_same_organization_payload_from_reappearing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+            result = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            Path(result["path"]).unlink()
+
+            payload = render_search_payload(
+                search_multi_source_entries(root, "shared organization", organization_sources=sources, top_k=5),
+                root,
+            )
+
+        self.assertEqual(payload, [])
+
+    def test_adopting_organization_card_installs_card_bound_skill_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            skill_dir = org / "kb" / "trusted" / "skills" / "bundle-demo" / "skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Shared Skill.\n---\n\nUse shared Skill.",
+                encoding="utf-8",
+            )
+            expected_hash = skill_directory_content_hash(skill_dir)
+            card = load_yaml_file(org / "kb" / "trusted" / "org-card.yaml")
+            card["organization_proposal"] = {
+                "skill_dependencies": [
+                    {
+                        "id": "demo-skill",
+                        "sharing_mode": "card-bound-bundle",
+                        "bundle_id": "skill-bundle-demo",
+                        "bundle_path": "skills/bundle-demo/skill",
+                        "content_hash": expected_hash,
+                        "version_time": "2026-04-24T12:00:00Z",
+                        "original_author": "alice",
+                        "readonly_when_imported": True,
+                        "update_policy": "original_author_only",
+                    }
+                ]
+            }
+            write_yaml_file(org / "kb" / "trusted" / "org-card.yaml", card)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+
+            result = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            installed = sorted((root / ".local" / "organization_skills" / "skill-bundle-demo").rglob("SKILL.md"))
+            bundle_metadata = load_yaml_file(root / ".local" / "organization_skills" / "skill-bundle-demo" / "metadata.yaml")
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["installed_skill_bundles"]["ok"], result)
+        self.assertEqual(len(installed), 1)
+        self.assertEqual(bundle_metadata["latest_version"]["content_hash"], expected_hash)
+
+    def test_same_id_organization_card_with_new_hash_surfaces_after_prior_adoption(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+            adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            changed = load_yaml_file(org / "kb" / "trusted" / "org-card.yaml")
+            changed["use"]["guidance"] = "Organization published a new content version."
+            write_yaml_file(org / "kb" / "trusted" / "org-card.yaml", changed)
+
+            payload = render_search_payload(
+                search_multi_source_entries(root, "shared organization", organization_sources=sources, top_k=5),
+                root,
+            )
+
+        self.assertEqual([item["source_info"]["kind"] for item in payload], ["local", "organization"])
+        self.assertRegex(payload[0]["id"], r"^cand-\d{8}T\d{6}Z-inst[0-9a-f]{8}-[0-9a-f]{6}$")
+        self.assertEqual(payload[1]["id"], "org-card")
+
+    def test_reusing_organization_card_updates_existing_adoption_usage_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+            first = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            second = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            adopted = load_yaml_file(Path(first["path"]))
+
+        self.assertTrue(first["created"])
+        self.assertFalse(second["created"])
+        self.assertEqual(first["path"], second["path"])
+        self.assertEqual(adopted[ADOPTION_KEY]["hit_count"], 2)
+        self.assertEqual(second["hit_count"], 2)
+        self.assertEqual(adoption_state(adopted), "clean")
+
+    def test_adoption_state_detects_local_divergence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            org = root / "org"
+            self._write_org_card(org)
+            sources = [{"path": str(org), "organization_id": "sandbox"}]
+            initial = build_search_payload(root, "shared organization", organization_sources=sources)
+            result = adopt_organization_entry_by_source_info(
+                root,
+                "org-card",
+                sources,
+                source_info=initial["results"][0]["source_info"],
+            )
+            adopted_path = Path(result["path"])
+            adopted = load_yaml_file(adopted_path)
+            adopted["use"]["guidance"] = "Local maintenance changed this card."
+            write_yaml_file(adopted_path, adopted)
+            changed = load_yaml_file(adopted_path)
+
+        self.assertEqual(adoption_state(changed), "diverged")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_sharing.py
+++ b/tests/test_skill_sharing.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_kb.org_outbox import build_organization_outbox
+from local_kb.skill_sharing import (
+    annotate_dependencies_with_registry_status,
+    build_card_skill_dependency_manifest,
+    consolidate_imported_skill_bundles,
+    extract_skill_dependencies,
+    install_imported_skill_bundle_version,
+    install_approved_organization_skill,
+    load_organization_skill_registry,
+    select_latest_skill_bundle_versions,
+    skill_auto_install_eligibility,
+    skill_directory_content_hash,
+)
+from local_kb.store import load_yaml_file, write_yaml_file
+
+
+class SkillSharingTests(unittest.TestCase):
+    def _card(self) -> dict:
+        return {
+            "id": "skill-backed-card",
+            "title": "Skill backed card",
+            "type": "model",
+            "scope": "public",
+            "status": "trusted",
+            "confidence": 0.8,
+            "domain_path": ["codex", "workflow", "skills"],
+            "tags": ["skill"],
+            "trigger_keywords": ["skill"],
+            "required_skills": ["demo-skill"],
+            "recommended_skills": [{"id": "missing-skill"}],
+            "if": {"notes": "A card relies on a local Skill."},
+            "action": {"description": "Declare the dependency as metadata."},
+            "predict": {"expected_result": "Maintainers can review card and Skill together."},
+            "use": {"guidance": "Do not auto-install the Skill."},
+        }
+
+    def test_extract_skill_dependencies_supports_required_and_recommended_fields(self) -> None:
+        dependencies = extract_skill_dependencies(self._card())
+
+        self.assertEqual(
+            dependencies,
+            [
+                {"id": "demo-skill", "requirement": "required"},
+                {"id": "missing-skill", "requirement": "recommended"},
+            ],
+        )
+
+    def test_dependency_manifest_builds_card_bound_skill_bundle_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = root / ".agents" / "skills" / "demo-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Demo Skill for tests.\n---\n\nUse this skill.",
+                encoding="utf-8",
+            )
+
+            manifest = build_card_skill_dependency_manifest(root, self._card(), codex_home=root / ".codex")
+
+        self.assertEqual(manifest[0]["status"], "installed")
+        self.assertEqual(manifest[0]["description"], "Demo Skill for tests.")
+        self.assertEqual(manifest[0]["sharing_mode"], "card-bound-bundle")
+        self.assertTrue(manifest[0]["bundle_id"].startswith("skill-bundle-"))
+        self.assertTrue(manifest[0]["content_hash"].startswith("sha256:"))
+        self.assertTrue(manifest[0]["readonly_when_imported"])
+        self.assertEqual(manifest[0]["update_policy"], "original_author_only")
+        self.assertEqual(manifest[1]["status"], "missing")
+        self.assertEqual(manifest[1]["sharing_mode"], "missing")
+
+    def test_outbox_proposal_includes_card_bound_skill_bundle_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = root / ".agents" / "skills" / "demo-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Demo Skill for tests.\n---\n\nUse this skill.",
+                encoding="utf-8",
+            )
+            write_yaml_file(root / "kb" / "public" / "skill-backed-card.yaml", self._card())
+
+            result = build_organization_outbox(root, organization_id="sandbox")
+            proposal = load_yaml_file(Path(result["created"][0]["path"]))
+            dependencies = proposal["organization_proposal"]["skill_dependencies"]
+            copied_skill_exists = (Path(result["outbox_dir"]) / dependencies[0]["bundle_path"] / "SKILL.md").exists()
+            copied_metadata_exists = (Path(result["outbox_dir"]) / dependencies[0]["bundle_metadata_path"]).exists()
+
+        self.assertEqual([item["id"] for item in dependencies], ["demo-skill", "missing-skill"])
+        self.assertEqual(dependencies[0]["sharing_mode"], "card-bound-bundle")
+        self.assertEqual(dependencies[1]["sharing_mode"], "missing")
+        self.assertTrue(dependencies[0]["bundle_id"].startswith("skill-bundle-"))
+        self.assertTrue(dependencies[0]["bundle_path"])
+        self.assertTrue(copied_skill_exists)
+        self.assertTrue(copied_metadata_exists)
+
+    def test_latest_skill_bundle_version_is_selected_by_version_time(self) -> None:
+        latest = select_latest_skill_bundle_versions(
+            [
+                {
+                    "bundle_id": "bundle-a",
+                    "content_hash": "sha256:" + "1" * 64,
+                    "version_time": "2026-04-24T10:00:00Z",
+                },
+                {
+                    "bundle_id": "bundle-a",
+                    "content_hash": "sha256:" + "2" * 64,
+                    "version_time": "2026-04-24T12:00:00Z",
+                },
+            ]
+        )
+
+        self.assertEqual(latest["bundle-a"]["content_hash"], "sha256:" + "2" * 64)
+
+    def test_imported_skill_bundle_consolidation_keeps_latest_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            older_skill = root / "older"
+            newer_skill = root / "newer"
+            older_skill.mkdir(parents=True)
+            newer_skill.mkdir(parents=True)
+            (older_skill / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Older Skill.\n---\n\nold",
+                encoding="utf-8",
+            )
+            (newer_skill / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Newer Skill.\n---\n\nnew",
+                encoding="utf-8",
+            )
+            bundle_id = "skill-bundle-demo"
+            install_imported_skill_bundle_version(
+                repo,
+                {
+                    "bundle_id": bundle_id,
+                    "id": "demo-skill",
+                    "version_time": "2026-04-24T10:00:00Z",
+                    "content_hash": skill_directory_content_hash(older_skill),
+                },
+                older_skill,
+                source_card_id="card-a",
+            )
+            install_imported_skill_bundle_version(
+                repo,
+                {
+                    "bundle_id": bundle_id,
+                    "id": "demo-skill",
+                    "version_time": "2026-04-24T12:00:00Z",
+                    "content_hash": skill_directory_content_hash(newer_skill),
+                },
+                newer_skill,
+                source_card_id="card-b",
+            )
+
+            result = consolidate_imported_skill_bundles(repo)
+            remaining = sorted((repo / ".local" / "organization_skills" / bundle_id / "versions").rglob("SKILL.md"))
+            remaining_last_line = remaining[0].read_text(encoding="utf-8").splitlines()[-1]
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["bundle_count"], 1)
+        self.assertEqual(result["removed_count"], 1)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining_last_line, "new")
+
+    def test_skill_registry_loads_three_review_states_and_auto_install_eligibility(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(
+                root / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {
+                            "id": "approved-skill",
+                            "status": "approved",
+                            "version": "1.0.0",
+                            "source_repo": "https://example.invalid/skills.git",
+                            "content_hash": "sha256:" + "a" * 64,
+                        },
+                        {"id": "candidate-skill", "status": "candidate"},
+                        {"id": "rejected-skill", "status": "rejected"},
+                    ]
+                },
+            )
+
+            registry = load_organization_skill_registry(root)
+            approved = skill_auto_install_eligibility(
+                registry["by_id"]["approved-skill"],
+                local_policy_allows=True,
+            )
+            candidate = skill_auto_install_eligibility(
+                registry["by_id"]["candidate-skill"],
+                local_policy_allows=True,
+            )
+
+        self.assertTrue(registry["ok"], registry)
+        self.assertTrue(approved["eligible"], approved)
+        self.assertFalse(candidate["eligible"])
+        self.assertIn("Skill is not approved", candidate["reasons"])
+
+    def test_skill_registry_indexes_latest_bundle_version_even_when_ids_repeat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(
+                root / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {
+                            "id": "demo-skill",
+                            "bundle_id": "bundle-a",
+                            "status": "approved",
+                            "version_time": "2026-04-24T10:00:00Z",
+                            "source_repo": "https://example.invalid/skills.git",
+                            "content_hash": "sha256:" + "1" * 64,
+                        },
+                        {
+                            "id": "demo-skill",
+                            "bundle_id": "bundle-a",
+                            "status": "approved",
+                            "version_time": "2026-04-24T12:00:00Z",
+                            "source_repo": "https://example.invalid/skills.git",
+                            "content_hash": "sha256:" + "2" * 64,
+                        },
+                    ]
+                },
+            )
+
+            registry = load_organization_skill_registry(root)
+            annotated = annotate_dependencies_with_registry_status(
+                [{"id": "demo-skill", "bundle_id": "bundle-a", "requirement": "required"}],
+                registry,
+                local_policy_allows_auto_install=True,
+            )
+
+        self.assertTrue(registry["ok"], registry)
+        self.assertEqual(registry["by_bundle_id"]["bundle-a"]["content_hash"], "sha256:" + "2" * 64)
+        self.assertEqual(annotated[0]["registry_status"], "approved")
+        self.assertEqual(annotated[0]["registry_version"], "2026-04-24T12:00:00Z")
+        self.assertTrue(annotated[0]["auto_install"]["eligible"], annotated)
+
+    def test_skill_registry_rejects_unknown_state_and_unpinned_approved_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(
+                root / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {"id": "bad-state", "status": "blocked"},
+                        {"id": "bad-approved", "status": "approved"},
+                    ]
+                },
+            )
+
+            registry = load_organization_skill_registry(root)
+
+        self.assertFalse(registry["ok"])
+        self.assertIn("skill bad-state has invalid status: blocked", registry["errors"])
+        self.assertIn("approved skill bad-approved must pin version", registry["errors"])
+        self.assertIn("approved skill bad-approved must pin sha256 content_hash", registry["errors"])
+
+    def test_dependencies_are_annotated_with_registry_status_and_install_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_yaml_file(
+                root / "skills" / "registry.yaml",
+                {
+                    "skills": [
+                        {
+                            "id": "demo-skill",
+                            "status": "approved",
+                            "version": "1.0.0",
+                            "source_repo": "https://example.invalid/skills.git",
+                            "content_hash": "sha256:" + "a" * 64,
+                        }
+                    ]
+                },
+            )
+            registry = load_organization_skill_registry(root)
+
+            annotated = annotate_dependencies_with_registry_status(
+                [{"id": "demo-skill", "requirement": "required"}, {"id": "missing-skill", "requirement": "recommended"}],
+                registry,
+                local_policy_allows_auto_install=True,
+            )
+
+        self.assertEqual(annotated[0]["registry_status"], "approved")
+        self.assertTrue(annotated[0]["auto_install"]["eligible"])
+        self.assertEqual(annotated[1]["registry_status"], "missing")
+        self.assertFalse(annotated[1]["auto_install"]["eligible"])
+
+    def test_install_approved_organization_skill_verifies_hash_and_existing_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_root = root / "skill-source"
+            skill_dir = source_root / "demo-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: demo-skill\ndescription: Approved demo Skill.\n---\n\nUse this Skill.",
+                encoding="utf-8",
+            )
+            content_hash = skill_directory_content_hash(skill_dir)
+            skill = {
+                "id": "demo-skill",
+                "bundle_id": "skill-bundle-demo",
+                "status": "approved",
+                "version": "1.0.0",
+                "source_repo": str(source_root),
+                "source_path": "demo-skill",
+                "content_hash": content_hash,
+            }
+            codex_home = root / ".codex"
+
+            installed = install_approved_organization_skill(
+                skill,
+                codex_home=codex_home,
+                local_policy_allows=True,
+            )
+            bad_hash = install_approved_organization_skill(
+                {**skill, "id": "bad-skill", "content_hash": "sha256:" + "b" * 64},
+                codex_home=codex_home,
+                local_policy_allows=True,
+            )
+            (codex_home / "skills" / "skill-bundle-demo" / "SKILL.md").write_text("different", encoding="utf-8")
+            conflict = install_approved_organization_skill(
+                skill,
+                codex_home=codex_home,
+                local_policy_allows=True,
+            )
+            installed_path_exists = (codex_home / "skills" / "skill-bundle-demo" / "SKILL.md").exists()
+
+        self.assertTrue(installed["ok"], installed)
+        self.assertEqual(installed["status"], "installed")
+        self.assertTrue(installed_path_exists)
+        self.assertFalse(bad_hash["ok"])
+        self.assertEqual(bad_hash["status"], "hash_mismatch")
+        self.assertFalse(conflict["ok"])
+        self.assertEqual(conflict["status"], "existing_version_conflict")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft PR for the pre-friend multi-machine organization KB test.

Includes:
- optional organization mode settings, source validation, local mirror loading, source labels, adoption, outbox, and maintenance helpers;
- organization contribution and maintenance skills/automations installed by the normal installer;
- GitHub organization KB check and auto-merge workflow templates;
- UI updates for source filtering, organization status, settings, and Skill dependency display;
- functional acceptance and structure audit docs;
- tests covering organization connection, multi-source search, adoption, outbox, contribution branch prep, cleanup, Skill bundles, and automation.

Validation already run locally:
- `python scripts/install_codex_kb.py --json`
- `python scripts/install_codex_kb.py --check --json`
- `python scripts/kb_org_check.py --org-root .local/organization_sources/khaos-org-kb-sandbox`
- `python scripts/kb_desktop.py --repo-root . --check --language zh-CN`
- `python scripts/kb_org_outbox.py --repo-root . --organization-id sandbox --dry-run`
- `python -m unittest discover -s tests -q` (168 tests)

This branch is meant for the first real friend-machine smoke test before any release tag or main merge.